### PR TITLE
Fix query in prompt template

### DIFF
--- a/prompt_template.txt
+++ b/prompt_template.txt
@@ -181,7 +181,7 @@ HTML:
 </html>
 
 
-Query: Click on the Button 'First Button'
+Query: Click on the Button 'Action Button'
 
 Completion:
 ```python


### PR DESCRIPTION
Fix query in example prompt

The query says click on 'First Button'. But the completion code clicks on 'Action Button'.

