### PR TITLE
Feature: Add playwright support in build command

### DIFF
--- a/prompt_template_playwright.txt
+++ b/prompt_template_playwright.txt
@@ -1,0 +1,207 @@
+Your goal is to write Playwright Python code to answer queries.
+
+Your answer must be a Python markdown only.
+You can have access to external websites and libraries.
+
+You can assume the following code has been executed:
+```python
+from playwright.sync_api import sync_playwright
+
+playwright = sync_playwright().start()
+browser = playwright.chromium.launch()
+page = browser.new_page()
+```
+
+---
+
+HTML:
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mock Search Page</title>
+</head>
+<body>
+    <h1>Search Page Example</h1>
+    <input id="searchBar" type="text" placeholder="Type here to search...">
+    <button id="searchButton">Search</button>
+    <script>
+        document.getElementById('searchButton').onclick = function() {{
+            var searchText = document.getElementById('searchBar').value;
+            alert("Searching for: " + searchText);
+        }};
+    </script>
+</body>
+</html>
+
+Query: Click on the search bar 'Type here to search...', type 'selenium', and press the 'Enter' key
+
+Completion:
+```python
+# Let's proceed step by step.
+# First we need to identify the component first, then we can click on it.
+
+# Based on the HTML, the link can be uniquely identified using the ID "searchBar"
+# Click on the search bar
+search_bar = page.locator('#searchBar')
+search_bar.click()
+
+# Type 'selenium' into the search bar
+page.type('#searchBar', 'selenium')
+
+# Press the 'Enter' key
+page.keyboard.press('Enter')
+
+```
+
+---
+
+HTML:
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Mock Page for Selenium</title>
+</head>
+<body>
+    <h1>Welcome to the Mock Page</h1>
+    <div id="links">
+        <a href="#link1" id="link1">Link 1</a>
+        <br>
+        <a href="#link2" class="link">Link 2</a>
+        <br>
+    </div>
+</body>
+</html>
+
+Query: Click on the title Link 1 and then click on the title Link 2
+
+Completion:
+```python
+# Let's proceed step by step.
+# First we need to identify the first component, then we can click on it. Then we can identify the second component and click on it.
+
+# Based on the HTML, the first link the link can be uniquely identified using the ID "link1"
+# Let's use this ID with playwright to identify the link
+link1 = page.locator('#link1')
+
+# Then we click on the link
+link1.click()
+
+# The other link can be uniquely identified using the class "link"
+# Let's use this class to identify the link
+link2 = page.locator('.link')
+
+# Click on the element found
+link2.click()
+```
+
+---
+
+HTML:
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mock Page</title>
+</head>
+<body>
+    <p id="para1">This is the first paragraph.</p>
+    <p id="para2">This is the second paragraph.</p>
+    <p id="para3">This is the third paragraph, which we will select and copy.</p>
+    <p id="para4">This is the fourth paragraph.</p>
+</body>
+</html>
+
+Query: Select the text inside the third paragraph
+
+Completion:
+```python
+# Let's proceed step by step.
+
+# To select a paragraph, we can execute a JS script to select the text using the DOM
+# In the provided HTML, the third paragraph can be identified using the ID "para3"
+# We need to use getElementById to select the paragraph precisely
+js_script = """
+    // This part depends on the specific HTML, here is the identified ID "para3"
+    var para = document.getElementById('para3');
+    // The rest is standard
+    if (document.body.createTextRange) {{
+        var range = document.body.createTextRange();
+        range.moveToElementText(para);
+        range.select();
+    }} else if (window.getSelection) {{
+        var selection = window.getSelection();
+        var range = document.createRange();
+        range.selectNodeContents(para);
+        selection.removeAllRanges();
+        selection.addRange(range);
+    }}
+"""
+
+# Then we execute JavaScript
+page.evaluate(js_script)
+```
+
+---
+
+HTML:
+
+Query: Scroll up a bit
+
+Completion:
+```python
+# Let's proceed step by step.
+# We don't need to use the HTML data as this is a stateless operation.
+# 200 pixels should be sufficient. Let's execute the JavaScript to scroll up.
+
+page.evaluate("window.scrollBy(0, 200)")
+```
+
+---
+
+---
+
+HTML:
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Enhanced Mock Page for Selenium Testing</title>
+</head>
+<body>
+    <h1>Enhanced Test Page for Selenium</h1>
+    <div class="container">
+        <button id="firstButton" onclick="alert('First button clicked!');">First Button</button>
+        <!-- This is the button we're targeting with the class name "action-btn" -->
+        <button class="action-btn" onclick="alert('Action button clicked!');">Action Button</button>
+        <div class="nested-container">
+            <button id="testButton" onclick="alert('Test Button clicked!');">Test Button</button>
+        </div>
+        <button class="hidden" onclick="alert('Hidden button clicked!');">Hidden Button</button>
+    </div>
+</body>
+</html>
+
+
+Query: Click on the Button 'Action Button'
+
+Completion:
+```python
+# Let's proceed step by step.
+# First we need to identify the button first, then we can click on it.
+
+# Based on the HTML provided, we need to devise the best strategy to select the button.
+# The action button can be identified using the class name "action-btn"
+action_button = page.locator('.action-btn')
+
+# Then we can click on it
+action_button.click()
+```
+
+---
+
+HTML:
+{context_str}
+Query: {query_str}
+Completion:
+```python
+# Let's proceed step by step.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["ruff", "ipykernel"]
+playwright = ["playwright==1.42.0"]
 
 [project.urls]
 "Homepage" = "https://mithrilsecurity.io"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,3 +71,4 @@ dev = ["ruff", "ipykernel"]
 [project.scripts]
 lavague-build = "lavague:build"
 lavague-launch = "lavague:launch"
+lavague-build-playwright = "lavague:build_playwright"

--- a/src/lavague/__init__.py
+++ b/src/lavague/__init__.py
@@ -1,6 +1,6 @@
 
 from .telemetry import send_telemetry
-from .utils import load_action_engine, load_instructions
+from .utils import load_action_engine, load_instructions, convert_to_executable_code
 from .command_center import CommandCenter
 
 import os
@@ -26,19 +26,6 @@ def import_from_path(path):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
-
-def convert_to_executable_code(func_code):
-    # Indent the provided code properly
-    indented_code = '\n'.join(['    ' + line for line in func_code.strip().split('\n')])
-
-    # Define a wrapper function and place the provided code inside it
-    wrapper_code = f'''
-import asyncio
-async def wrapper_func():
-{indented_code}
-asyncio.run(wrapper_func())
-    '''
-    return wrapper_code
 
 
 def build():
@@ -177,7 +164,7 @@ def build_playwright():
         source_code_lines = [line.strip() for line in source_code_lines[:-1]]
         
         # Execute the import lines
-        import_lines = [line for line in source_code_lines if line.startswith("from") or line.startswith("import")] 
+        import_lines = [line for line in source_code_lines if line.startswith("from") or line.startswith("import")]
         exec(convert_to_executable_code("\n".join(import_lines)))
 
         output = "\n".join(source_code_lines)

--- a/src/lavague/__init__.py
+++ b/src/lavague/__init__.py
@@ -11,6 +11,11 @@ from tqdm import tqdm
 import inspect
 
 import warnings
+import asyncio
+# We need nest_asyncio to use asyncio.run inside exec function
+import nest_asyncio
+nest_asyncio.apply()
+
 warnings.filterwarnings("ignore")
 
 
@@ -21,6 +26,20 @@ def import_from_path(path):
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+def convert_to_executable_code(func_code):
+    # Indent the provided code properly
+    indented_code = '\n'.join(['    ' + line for line in func_code.strip().split('\n')])
+
+    # Define a wrapper function and place the provided code inside it
+    wrapper_code = f'''
+import asyncio
+async def wrapper_func():
+{indented_code}
+asyncio.run(wrapper_func())
+    '''
+    return wrapper_code
+
 
 def build():
     parser = argparse.ArgumentParser(description='Process a file.')
@@ -124,3 +143,82 @@ def launch():
     base_url, instructions = load_instructions(file_path)
         
     command_center.run(base_url, instructions)
+
+def build_playwright():
+    async def _build_playwright():
+        parser = argparse.ArgumentParser(description='Process a file.')
+
+        # Add the arguments
+        parser.add_argument('--file_path',
+                        type=str,
+                        required=True,
+                        help='the path to the file')
+
+        parser.add_argument('--config_path',
+                        type=str,
+                        required=True,
+                        help='the path to the Python config file')
+        # Execute the parse_args() method
+        args = parser.parse_args()
+        
+        file_path = args.file_path
+        config_path = args.config_path
+        
+        # Load the action engine and driver from config file
+        action_engine, get_driver = load_action_engine(config_path, streaming=False, use_playwright=True)
+        
+        driver = await get_driver()
+        
+        # Gets the original source code of the get_driver method
+        source_code = inspect.getsource(get_driver)
+
+        # Split the source code into lines and remove the first line (method definition)
+        source_code_lines = source_code.splitlines()[1:]
+        source_code_lines = [line.strip() for line in source_code_lines[:-1]]
+        
+        # Execute the import lines
+        import_lines = [line for line in source_code_lines if line.startswith("from") or line.startswith("import")] 
+        exec(convert_to_executable_code("\n".join(import_lines)))
+
+        output = "\n".join(source_code_lines)
+        
+        base_url, instructions = load_instructions(file_path)
+
+        await driver.goto(base_url)
+        output += f"\nawait page.goto('{base_url.strip()}')\n"
+
+        template_code = """\n########################################\n# Query: {instruction}\n# Code:\n{code}"""
+
+        file_path = os.path.basename(file_path)
+        file_path, _ = os.path.splitext(file_path)
+        
+        config_path = os.path.basename(config_path)
+        config_path, _ = os.path.splitext(config_path)
+        
+        output_fn = file_path + "_" + config_path + ".py"
+        full_exec_code = ""
+        
+        for instruction in tqdm(instructions):
+            print(f"Processing instruction: {instruction}")
+            html = await driver.content()
+            code, source_nodes = action_engine.get_action(instruction, html)
+            try:
+                full_code = output + '\n' + code
+                full_exec_code = convert_to_executable_code(full_code)
+                print(f"Executing code:\n {full_exec_code}")
+                exec(full_exec_code)
+            except Exception as e:
+                print(f"Error in code execution: {code}")
+                print("Error:", e)
+                print(f"Saving output to {output_fn}")
+                with open(output_fn, "w") as file:
+                    file.write(output)
+                    break
+            output += "\n" + template_code.format(instruction=instruction, code=code).strip()
+            send_telemetry(action_engine.llm.metadata.model_name, code, b"", html, source_nodes, instruction, base_url, "Lavague-build")  
+
+        print(f"Saving output to {output_fn}")
+        with open(output_fn, "w") as file:
+            file.write(full_exec_code)
+    
+    asyncio.run(_build_playwright())

--- a/src/lavague/__init__.py
+++ b/src/lavague/__init__.py
@@ -1,6 +1,6 @@
 
 from .telemetry import send_telemetry
-from .utils import load_action_engine, load_instructions, convert_to_executable_code
+from .utils import load_action_engine, load_instructions, wrap_code_in_async_function
 from .command_center import CommandCenter
 
 import os
@@ -165,7 +165,7 @@ def build_playwright():
         
         # Execute the import lines
         import_lines = [line for line in source_code_lines if line.startswith("from") or line.startswith("import")]
-        exec(convert_to_executable_code("\n".join(import_lines)))
+        exec(wrap_code_in_async_function("\n".join(import_lines)))
 
         output = "\n".join(source_code_lines)
         
@@ -191,7 +191,7 @@ def build_playwright():
             code, source_nodes = action_engine.get_action(instruction, html)
             try:
                 full_code = output + '\n' + code
-                full_exec_code = convert_to_executable_code(full_code)
+                full_exec_code = wrap_code_in_async_function(full_code)
                 print(f"Executing code:\n {full_exec_code}")
                 exec(full_exec_code)
             except Exception as e:

--- a/src/lavague/defaults.py
+++ b/src/lavague/defaults.py
@@ -46,3 +46,10 @@ def default_get_driver():
     
     driver = webdriver.Chrome(service=webdriver_service, options=chrome_options)
     return driver
+
+async def get_playwright_driver():
+    from playwright.async_api import async_playwright
+    p = await async_playwright().__aenter__()
+    browser = await p.chromium.launch()
+    page = await browser.new_page()
+    return page

--- a/src/lavague/defaults.py
+++ b/src/lavague/defaults.py
@@ -48,7 +48,10 @@ def default_get_driver():
     return driver
 
 async def get_playwright_driver():
-    from playwright.async_api import async_playwright
+    try:
+        from playwright.async_api import async_playwright
+    except (ImportError, ModuleNotFoundError) as error:
+        raise ImportError("Please install playwright using `pip install pytest-playwright` and then `playwright install` to install the necessary browser drivers") from error
     p = await async_playwright().__aenter__()
     browser = await p.chromium.launch()
     page = await browser.new_page()

--- a/src/lavague/defaults.py
+++ b/src/lavague/defaults.py
@@ -51,7 +51,7 @@ async def get_playwright_driver():
     try:
         from playwright.async_api import async_playwright
     except (ImportError, ModuleNotFoundError) as error:
-        raise ImportError("Please install playwright using `pip install pytest-playwright` and then `playwright install` to install the necessary browser drivers") from error
+        raise ImportError("Please install playwright using `pip install playwright` and then `playwright install` to install the necessary browser drivers") from error
     p = await async_playwright().__aenter__()
     browser = await p.chromium.launch()
     page = await browser.new_page()

--- a/src/lavague/prompts.py
+++ b/src/lavague/prompts.py
@@ -415,3 +415,213 @@ Completion:
 # Let's proceed step by step.
 
 '''
+
+DEFAULT_PLAYWRIGHT_PROMPT = '''
+Your goal is to write Playwright Python code to answer queries.
+
+Your answer must be a Python markdown only.
+You can have access to external websites and libraries.
+
+You can assume the following code has been executed:
+```python
+from playwright.async_api import async_playwright
+p = await async_playwright().__aenter__()
+browser = await p.chromium.launch()
+page = await browser.new_page()
+```
+
+---
+
+HTML:
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mock Search Page</title>
+</head>
+<body>
+    <h1>Search Page Example</h1>
+    <input id="searchBar" type="text" placeholder="Type here to search...">
+    <button id="searchButton">Search</button>
+    <script>
+        document.getElementById('searchButton').onclick = function() {{
+            var searchText = document.getElementById('searchBar').value;
+            alert("Searching for: " + searchText);
+        }};
+    </script>
+</body>
+</html>
+
+Query: Click on the search bar 'Type here to search...', type 'selenium', and press the 'Enter' key
+
+Completion:
+```python
+# Let's proceed step by step.
+# First we need to identify the component first, then we can click on it.
+
+# Based on the HTML, the link can be uniquely identified using the ID "searchBar"
+# Click on the search bar
+search_bar = page.locator('#searchBar')
+search_bar.click()
+
+# Type 'selenium' into the search bar
+await page.type('#searchBar', 'selenium')
+
+# Press the 'Enter' key
+await page.keyboard.press('Enter')
+
+```
+
+---
+
+HTML:
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Mock Page for Selenium</title>
+</head>
+<body>
+    <h1>Welcome to the Mock Page</h1>
+    <div id="links">
+        <a href="#link1" id="link1">Link 1</a>
+        <br>
+        <a href="#link2" class="link">Link 2</a>
+        <br>
+    </div>
+</body>
+</html>
+
+Query: Click on the title Link 1 and then click on the title Link 2
+
+Completion:
+```python
+# Let's proceed step by step.
+# First we need to identify the first component, then we can click on it. Then we can identify the second component and click on it.
+
+# Based on the HTML, the first link the link can be uniquely identified using the ID "link1"
+# Let's use this ID with playwright to identify the link
+link1 = page.locator('#link1')
+
+# Then we click on the link
+await link1.click()
+
+# The other link can be uniquely identified using the class "link"
+# Let's use this class to identify the link
+link2 = page.locator('.link')
+
+# Click on the element found
+await link2.click()
+```
+
+---
+
+HTML:
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Mock Page</title>
+</head>
+<body>
+    <p id="para1">This is the first paragraph.</p>
+    <p id="para2">This is the second paragraph.</p>
+    <p id="para3">This is the third paragraph, which we will select and copy.</p>
+    <p id="para4">This is the fourth paragraph.</p>
+</body>
+</html>
+
+Query: Select the text inside the third paragraph
+
+Completion:
+```python
+# Let's proceed step by step.
+
+# To select a paragraph, we can execute a JS script to select the text using the DOM
+# In the provided HTML, the third paragraph can be identified using the ID "para3"
+# We need to use getElementById to select the paragraph precisely
+js_script = """
+    // This part depends on the specific HTML, here is the identified ID "para3"
+    var para = document.getElementById('para3');
+    // The rest is standard
+    if (document.body.createTextRange) {{
+        var range = document.body.createTextRange();
+        range.moveToElementText(para);
+        range.select();
+    }} else if (window.getSelection) {{
+        var selection = window.getSelection();
+        var range = document.createRange();
+        range.selectNodeContents(para);
+        selection.removeAllRanges();
+        selection.addRange(range);
+    }}
+"""
+
+# Then we execute JavaScript
+await page.evaluate(js_script)
+```
+
+---
+
+HTML:
+
+Query: Scroll up a bit
+
+Completion:
+```python
+# Let's proceed step by step.
+# We don't need to use the HTML data as this is a stateless operation.
+# 200 pixels should be sufficient. Let's execute the JavaScript to scroll up.
+
+await page.evaluate("window.scrollBy(0, 200)")
+```
+
+---
+
+---
+
+HTML:
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Enhanced Mock Page for Selenium Testing</title>
+</head>
+<body>
+    <h1>Enhanced Test Page for Selenium</h1>
+    <div class="container">
+        <button id="firstButton" onclick="alert('First button clicked!');">First Button</button>
+        <!-- This is the button we're targeting with the class name "action-btn" -->
+        <button class="action-btn" onclick="alert('Action button clicked!');">Action Button</button>
+        <div class="nested-container">
+            <button id="testButton" onclick="alert('Test Button clicked!');">Test Button</button>
+        </div>
+        <button class="hidden" onclick="alert('Hidden button clicked!');">Hidden Button</button>
+    </div>
+</body>
+</html>
+
+
+Query: Click on the Button 'Action Button'
+
+Completion:
+```python
+# Let's proceed step by step.
+# First we need to identify the button first, then we can click on it.
+
+# Based on the HTML provided, we need to devise the best strategy to select the button.
+# The action button can be identified using the class name "action-btn"
+action_button = page.locator('.action-btn')
+
+# Then we can click on it
+await action_button.click()
+```
+
+---
+
+HTML:
+{context_str}
+Query: {query_str}
+Completion:
+```python
+# Let's proceed step by step.
+
+'''

--- a/src/lavague/utils.py
+++ b/src/lavague/utils.py
@@ -39,32 +39,79 @@ def load_instructions(path):
         
     return base_url, instructions
 
-def get_indented_code(code):
-    lines = code.split('\n')
+def add_indentation_to_code(code_to_indent: str, indentation_level=1):
+    '''
+    Adds indentation to the provided code so that it can be executed using exec
+    code_to_indent: str: The code that needs to be indented
+    indentation_level: int: The number of indentation levels to start with
+
+    Note: This function can only support at max 1 line of try and except block, as it resets the indentation level after that
+
+    Example:
+    code_to_indent =
+try:
+from playwright.async_api import async_playwright
+except (ImportError, ModuleNotFoundError) as error:
+raise ImportError("Please install playwright using `pip install pytest-playwright` and then `playwright install` to install the necessary browser drivers") from error
+p = await async_playwright().__aenter__()
+browser = await p.chromium.launch()
+page = await browser.new_page()
+return page
+
+will be converted to:
+
+    try:
+        from playwright.async_api import async_playwright
+    except (ImportError, ModuleNotFoundError) as error:
+        raise ImportError("Please install playwright using `pip install pytest-playwright` and then `playwright install` to install the necessary browser drivers") from error 
+    p = await async_playwright().__aenter__()
+    browser = await p.chromium.launch()
+    page = await browser.new_page()
+    return page
+
+    '''
+    lines = code_to_indent.split('\n')
     lines = [line.strip() for line in lines]
     lines = [line for line in lines if line]
 
     fixed_lines = []
-    indentation_level = 1
-
+    current_indentation_level = indentation_level
     for line in lines:
         if line.endswith(':'):
-            indentation_level = 1
-            fixed_lines.append('    ' * indentation_level + line)
-            indentation_level += 1
+            current_indentation_level = indentation_level
+            fixed_lines.append('    ' * current_indentation_level + line)
+            current_indentation_level += 1
         else:
-            fixed_lines.append('    ' * indentation_level + line)
-            # Try and except will have one lines, so we need to decrease the indentation level
-            indentation_level = 1
+            fixed_lines.append('    ' * current_indentation_level + line)
+            # Reset the indentation level after one line
+            current_indentation_level = indentation_level
 
-    # Join the lines with newline characters
     fixed_code = '\n'.join(fixed_lines)
 
     return fixed_code
 
-def convert_to_executable_code(func_code):
+def wrap_code_in_async_function(original_code: str):
+    '''
+    Wraps the provided code in an async function and executes it using asyncio.run
+    original_code: str:
+    from playwright.async_api import async_playwright
+    playwright = await async_playwright().start()
+    browser = await playwright.chromium.launch(headless = False)
+    page = await browser.new_page()
+    await page.goto("http://whatsmyuseragent.org/")
+
+    This will convert the code above into a code like this, so that it can be executed using exec
+    import asyncio
+    async def wrapper_func():
+        from playwright.async_api import async_playwright
+        playwright = await async_playwright().start()
+        browser = await playwright.chromium.launch(headless = False)
+        page = await browser.new_page()
+        await page.goto("http://whatsmyuseragent.org/")
+    asyncio.run(wrapper_func())
+    '''
     # Indent the provided code properly
-    indented_code = get_indented_code(func_code)
+    indented_code = add_indentation_to_code(original_code)
     print("indented_code --> ", indented_code)
 
     # Define a wrapper function and place the provided code inside it

--- a/src/lavague/utils.py
+++ b/src/lavague/utils.py
@@ -38,3 +38,40 @@ def load_instructions(path):
         instructions = [instruction.strip() for instruction in instructions[1:]]
         
     return base_url, instructions
+
+def get_indented_code(code):
+    lines = code.split('\n')
+    lines = [line.strip() for line in lines]
+    lines = [line for line in lines if line]
+
+    fixed_lines = []
+    indentation_level = 1
+
+    for line in lines:
+        if line.endswith(':'):
+            indentation_level = 1
+            fixed_lines.append('    ' * indentation_level + line)
+            indentation_level += 1
+        else:
+            fixed_lines.append('    ' * indentation_level + line)
+            # Try and except will have one lines, so we need to decrease the indentation level
+            indentation_level = 1
+
+    # Join the lines with newline characters
+    fixed_code = '\n'.join(fixed_lines)
+
+    return fixed_code
+
+def convert_to_executable_code(func_code):
+    # Indent the provided code properly
+    indented_code = get_indented_code(func_code)
+    print("indented_code --> ", indented_code)
+
+    # Define a wrapper function and place the provided code inside it
+    wrapper_code = f'''
+import asyncio
+async def wrapper_func():
+{indented_code}
+asyncio.run(wrapper_func())
+    '''
+    return wrapper_code


### PR DESCRIPTION
Partially closes: #1 

This PR adds a new command `lavague-build-playwright` to build playwright code similar to `lavague-build`.

We are using playwright async api, and i have created a new function for it without affecting any existing methods.

Command to run build playwright code
`!lavague-build-playwright --file_path hf.txt --config_path openai.py`

Other things that I tried which didn't worked:
- I also tried using playwright sync API in build such that the code looks similar to selenium and we don't need async await but it was throwing error: `error: It looks like you are using Playwright Sync API inside the asyncio loop.` I searched and found that sync api is not allowed in jupyter notebooks and collab as they are already in asyncio loop.

- I also tried implementing the launch method using both sync and async playwright but no luck as It uses gradio and gradio was switching threads and plawright is not thread aware. We can create a separate issue for this and look into it later.
