### PR TITLE
Add MacOS installation Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,7 @@ docs/_build/
 .env
 test.ipynb
 
+#virtual environemnt
+env/
+
 tests/*.py

--- a/docs/docs/get-started/setting-up-la-vague.md
+++ b/docs/docs/get-started/setting-up-la-vague.md
@@ -14,9 +14,13 @@ We provide two key installation options:
 
 ### Local setup
 
-To set-up LaVague in your local environment, you can run our `setup.sh` script:
+To set-up LaVague in your local linux environment, you can run our `setup.sh` script:
 
 `sudo bash setup.sh`
+
+To set-up LaVague in your local macos environment, you can run our `setup-macos.sh` script:
+
+`sudo bash setup-macos.sh`
 
 This will perform all necessary steps to set-up LaVague.
 

--- a/setup-macos.sh
+++ b/setup-macos.sh
@@ -47,7 +47,7 @@ CHROME_URL="${BASE_URL}/${OS}-${ARCH}/${CHROME_FILENAME}"
 echo $CHROME_URL
 
 
-# Download Chrome and Chromedriver then unzip downloaded files, move to home and clean up
+# Download Chromedriver then unzip downloaded files, move to home and clean up
 wget $DRIVER_URL
 unzip $DRIVER_FILENAME
 mv $DRIVER/ ~/
@@ -55,7 +55,7 @@ mv ~/$DRIVER ~/chromedriver-testing
 rm  $DRIVER_FILENAME
 
 
-# NOTE: Uncomment if Chromium/Google Chrome is not installed in a recognized location
+# Download Chrome binary then unzip downloaded files, move to home and clean up
 wget $CHROME_URL
 unzip $CHROME_FILENAME
 mv $CHROME/ ~/

--- a/setup-macos.sh
+++ b/setup-macos.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+
+# Base URL for downloads
+BASE_URL="https://storage.googleapis.com/chrome-for-testing-public/123.0.6312.105"
+
+# Determine OS
+OS="unknown"
+case "$(uname -s)" in
+    Linux*)     OS="linux";;
+    Darwin*)    OS="mac";;
+    CYGWIN*|MINGW32*|MSYS*|MINGW*) OS="win";;
+    *)          OS="unknown";;
+esac
+
+# Determine architecture
+ARCH="unknown"
+case "$(uname -m)" in
+    x86_64*)    ARCH="x64";;
+    arm64*)     ARCH="arm64";;
+    *)          ARCH="unknown";;
+esac
+
+
+if [[ $OS == "mac" ]]; then
+    # Special handling for Mac to differentiate between Intel (x64) and Apple Silicon (arm64)
+    if sysctl -n machdep.cpu.brand_string | grep -q "Intel"; then
+        ARCH="x64"
+    else
+        ARCH="arm64"
+    fi
+else
+    echo "Unsupported OS or architecture."
+    exit 1
+fi
+
+# Choose the right download based on your need: chrome, chromedriver, or chrome-headless-shell
+DRIVER="chromedriver-${OS}-${ARCH}"
+CHROME="chrome-${OS}-${ARCH}"
+
+# Construct the download URLs
+DRIVER_FILENAME="${DRIVER}.zip"
+DRIVER_URL="${BASE_URL}/${OS}-${ARCH}/${DRIVER_FILENAME}"
+echo $DRIVER_URL
+
+CHROME_FILENAME="${CHROME}.zip"
+CHROME_URL="${BASE_URL}/${OS}-${ARCH}/${CHROME_FILENAME}"
+echo $CHROME_URL
+
+
+# Download Chrome and Chromedriver then unzip downloaded files, move to home and clean up
+wget $DRIVER_URL
+unzip $DRIVER_FILENAME
+mv $DRIVER/ ~/
+mv ~/$DRIVER ~/chromedriver-testing
+rm  $DRIVER_FILENAME
+
+
+# NOTE: Uncomment if Chromium/Google Chrome is not installed in a recognized location
+wget $CHROME_URL
+unzip $CHROME_FILENAME
+mv $CHROME/ ~/
+mv ~/$CHROME/ ~/chrome-testing
+rm $CHROME_FILENAME
+
+
+# Update package lists and install necessary packages
+sudo apt update
+sudo apt install -y ca-certificates fonts-liberation unzip \
+libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libc6 \
+libcairo2 libcups2 libdbus-1-3 libexpat1 libfontconfig1 libgbm1 \
+libgcc1 libglib2.0-0 libgtk-3-0 libnspr4 libnss3 libpango-1.0-0 \
+libpangocairo-1.0-0 libstdc++6 libx11-6 libx11-xcb1 libxcb1 \
+libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 \
+libxrandr2 libxrender1 libxss1 libxtst6 lsb-release wget xdg-utils
+
+# Install LaVague from main of GitHub repo
+git clone https://github.com/lavague-ai/LaVague.git
+pip install -e LaVague
+
+# Change directory to LaVague
+cd LaVague
+
+# Print success message
+echo -e "\e[32mAll steps completed successfully.\e[0m"

--- a/setup.sh
+++ b/setup.sh
@@ -18,8 +18,12 @@ wget https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.94/linu
 unzip chrome-linux64.zip
 unzip chromedriver-linux64.zip
 rm chrome-linux64.zip chromedriver-linux64.zip
+
 mv chrome-linux64/ ~/
+mv ~/chrome-linux64/ ~/chrome-testing
 mv chromedriver-linux64/ ~/
+mv ~/chromedriver-linux64 ~/chromedriver-testing
+
 
 # Install LaVague from main of GitHub repo
 git clone https://github.com/lavague-ai/LaVague.git

--- a/setup.sh
+++ b/setup.sh
@@ -18,12 +18,8 @@ wget https://storage.googleapis.com/chrome-for-testing-public/122.0.6261.94/linu
 unzip chrome-linux64.zip
 unzip chromedriver-linux64.zip
 rm chrome-linux64.zip chromedriver-linux64.zip
-
 mv chrome-linux64/ ~/
-mv ~/chrome-linux64/ ~/chrome-testing
 mv chromedriver-linux64/ ~/
-mv ~/chromedriver-linux64 ~/chromedriver-testing
-
 
 # Install LaVague from main of GitHub repo
 git clone https://github.com/lavague-ai/LaVague.git

--- a/src/lavague/defaults.py
+++ b/src/lavague/defaults.py
@@ -35,15 +35,28 @@ def default_get_driver() -> SeleniumDriver:
     from selenium.webdriver.common.keys import Keys
     import os.path
 
+    # Paths to the chromedriver files
+    path_linux = f"{homedir}/chromedriver-mac-x64/chromedriver"
+    path_testing = f"{homedir}/chromedriver-testing/chromedriver"
+
     chrome_options = Options()
     chrome_options.add_argument("--headless")  # Ensure GUI is off
     chrome_options.add_argument("--no-sandbox")
     chrome_options.add_argument("--window-size=1600,900")
 
     homedir = os.path.expanduser("~")
-    # Uncomment if Chromium/Google Chrome is installed via our script
-    # chrome_options.binary_location = f"{homedir}/chrome-testing/chrome"
-    webdriver_service = Service(f"{homedir}/chromedriver-testing/chromedriver")
+    # Comment out binary location if Chromium/Google Chrome is already installed
+    if os.path.exists(path_linux):
+        chrome_options.binary_location = f"{homedir}/chrome-linux64/chrome"
+        webdriver_service = Service(f"{homedir}/chromedriver-linux64/chromedriver")
+    elif os.path.exists(path_testing):
+        chrome_options.binary_location = f"{homedir}/chrome-testing/chrome"
+        webdriver_service = Service(f"{homedir}/chromedriver-testing/chromedriver")
+    else:
+        raise FileNotFoundError("Neither chromedriver file exists.")
+
+
+
 
     driver = webdriver.Chrome(service=webdriver_service, options=chrome_options)
     return SeleniumDriver(driver)

--- a/src/lavague/defaults.py
+++ b/src/lavague/defaults.py
@@ -41,8 +41,9 @@ def default_get_driver() -> SeleniumDriver:
     chrome_options.add_argument("--window-size=1600,900")
 
     homedir = os.path.expanduser("~")
-    chrome_options.binary_location = f"{homedir}/chrome-linux64/chrome"
-    webdriver_service = Service(f"{homedir}/chromedriver-linux64/chromedriver")
+    # Uncomment if Chromium/Google Chrome is installed via our script
+    # chrome_options.binary_location = f"{homedir}/chrome-testing/chrome"
+    webdriver_service = Service(f"{homedir}/chromedriver-testing/chromedriver")
 
     driver = webdriver.Chrome(service=webdriver_service, options=chrome_options)
     return SeleniumDriver(driver)

--- a/src/lavague/defaults.py
+++ b/src/lavague/defaults.py
@@ -35,9 +35,7 @@ def default_get_driver() -> SeleniumDriver:
     from selenium.webdriver.common.keys import Keys
     import os.path
 
-    # Paths to the chromedriver files
-    path_linux = f"{homedir}/chromedriver-mac-x64/chromedriver"
-    path_testing = f"{homedir}/chromedriver-testing/chromedriver"
+
 
     chrome_options = Options()
     chrome_options.add_argument("--headless")  # Ensure GUI is off
@@ -45,12 +43,20 @@ def default_get_driver() -> SeleniumDriver:
     chrome_options.add_argument("--window-size=1600,900")
 
     homedir = os.path.expanduser("~")
-    # Comment out binary location if Chromium/Google Chrome is already installed
+
+    # Paths to the chromedriver files
+    path_linux = f"{homedir}/chromedriver-linux64/chromedriver"
+    path_testing = f"{homedir}/chromedriver-testing/chromedriver"
+    path_mac = "Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+    
+    # To avoid breaking change kept legacy linux64 path
     if os.path.exists(path_linux):
         chrome_options.binary_location = f"{homedir}/chrome-linux64/chrome"
         webdriver_service = Service(f"{homedir}/chromedriver-linux64/chromedriver")
     elif os.path.exists(path_testing):
-        chrome_options.binary_location = f"{homedir}/chrome-testing/chrome"
+        if os.path.exists(f"{homedir}/chrome-testing/{path_mac}"):
+            chrome_options.binary_location = f"{homedir}/chrome-testing/{path_mac}"
+        # Can add support here for other chrome binaries with else if statements
         webdriver_service = Service(f"{homedir}/chromedriver-testing/chromedriver")
     else:
         raise FileNotFoundError("Neither chromedriver file exists.")


### PR DESCRIPTION
Added macOS support via shell script that checks for x86 or arm. This logic could be used to condense down to one setup shell script.

I renamed chrome folders to -testing as to not have to update the logic in the python to check for the OS and CPU. I also had to update this renaming convention in  the default setup.sh.

    # Uncomment if Chromium/Google Chrome is installed via our script
    # chrome_options.binary_location = f"{homedir}/chrome-testing/chrome"
    webdriver_service = Service(f"{homedir}/chromedriver-testing/chromedriver")
   
I also found that binary_location is not needed for anyone that already has chrome installed.