### PR TITLE
Feature: Clean htmls to make it easier for LLMs to understand HTML content

### DIFF
--- a/src/lavague/driver.py
+++ b/src/lavague/driver.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any
 from selenium.webdriver.remote.webdriver import WebDriver
+from .html_utils import clean_html
 
 
 class AbstractDriver(ABC):
@@ -16,7 +17,12 @@ class AbstractDriver(ABC):
         pass
 
     @abstractmethod
-    def getHtml(self) -> str:
+    def getHtml(self, clean: bool = True) -> str:
+        '''
+        Returns the HTML of the current page.
+        If clean is True, We remove unnecessary tags and attributes from the HTML.
+        Clean HTMLs are easier to process for the LLM.
+        '''
         pass
 
     @abstractmethod
@@ -41,8 +47,9 @@ class SeleniumDriver(AbstractDriver):
     def goTo(self, url: str) -> None:
         self.driver.get(url)
 
-    def getHtml(self) -> str:
-        return self.driver.page_source
+    def getHtml(self, clean: bool = True) -> str:
+        html = self.driver.page_source
+        return clean_html(html) if clean else html
 
     def getScreenshot(self, filename: str) -> None:
         self.driver.save_screenshot(filename)

--- a/src/lavague/html_utils.py
+++ b/src/lavague/html_utils.py
@@ -1,0 +1,26 @@
+import re
+from typing import List
+
+def clean_html(html_to_clean: str, tags_to_remove: List[str] = ['style', 'svg', 'script'], attributes_to_keep: List[str] = ['id', 'href']) -> str:
+    """
+    Clean HTML content by removing specified tags and attributes while keeping specified attributes.
+
+    Args:
+        html_to_clean (str): The HTML content to clean.
+        tags_to_remove (List[str]): List of tags to remove from the HTML content. Default is ['style', 'svg', 'script'].
+        attributes_to_keep (List[str]): List of attributes to keep in the HTML tags. Default is ['id', 'href'].
+
+    Returns:
+        str: The cleaned HTML content.
+
+    Example:
+    >>> from clean_html_for_llm import clean_html
+    >>> cleaned_html = clean_html('<div id="main" style="color:red">Hello <script>alert("World")</script></div>', tags_to_remove=['script'], attributes_to_keep=['id'])
+    """
+    for tag in tags_to_remove:
+        html_to_clean = re.sub(rf'<{tag}[^>]*>.*?</{tag}>', '', html_to_clean, flags=re.DOTALL)
+
+    attributes_to_keep = '|'.join(attributes_to_keep)
+    pattern = rf'\b(?!({attributes_to_keep})\b)\w+(?:-\w+)?\s*=\s*["\'][^"\']*["\']'
+    cleaned_html = re.sub(pattern, '', html_to_clean)
+    return cleaned_html


### PR DESCRIPTION
Closes: #103 
I have published the code to clean html into a[ pip package](https://pypi.org/project/clean-html-for-llm/) and we are using that here to keep the code clean. It has zero dependency. It just uses regex to clean the html content so we can easily import in our code without worrying about anything else.

##Context
TLDR; clean html reduces the html size by ~10x and keeps the structure intact which helps LLMs to understand the content better.

https://drive.google.com/file/d/1TaS1h7dmgQfc1p9DQ13p7RswCmBGR8GQ/view?usp=sharing
Watch the last part (21:20) of the meeting where i explained the advantage of cleaning html before passing it to llm. We found that the html size if getting reduced by ~10x in almost all cases which removes a lot of noise and makes it easier for LLMs to understand the html content.
Also it keeps the HTML structure intact which we can use for other purpose in future.
Bonus: This also reduces the token count which reduces the cost for any paid LLM API by ~10x which is a huge number when deployed on scale.