### PR TITLE
Add Anthropics and Groq API configurations

### DIFF
--- a/examples/configurations/api/anthropic_api.py
+++ b/examples/configurations/api/anthropic_api.py
@@ -1,0 +1,19 @@
+import os
+from llama_index.llms.anthropic import Anthropic
+
+
+class AnthropicApiLLM(Anthropic):
+    # This class initializes the Anthropic API with selected models.
+    # Available models: claude-3-haiku-20240307, claude-3-sonnet-20240229, claude-3-opus-20240229
+    def __init__(
+            self,
+            model: str = "claude-3-haiku-20240307",
+            api_key: str = os.getenv("ANTHROPIC_API_KEY"),
+    ):
+        if api_key is None:
+            raise ValueError("ANTHROPIC_API_KEY environment variable is not set")
+
+        super().__init__(
+            model=model,
+            api_key=api_key,
+        )

--- a/examples/configurations/api/anthropic_api.py
+++ b/examples/configurations/api/anthropic_api.py
@@ -2,7 +2,7 @@ import os
 from llama_index.llms.anthropic import Anthropic
 
 
-class AnthropicApiLLM(Anthropic):
+class LLM(Anthropic):
     # This class initializes the Anthropic API with selected models.
     # Available models: claude-3-haiku-20240307, claude-3-sonnet-20240229, claude-3-opus-20240229
     def __init__(

--- a/examples/configurations/api/groq_api.py
+++ b/examples/configurations/api/groq_api.py
@@ -1,0 +1,19 @@
+import os
+from llama_index.llms.groq import Groq
+
+
+class GroqApiLLM(Groq):
+    # This class initializes the Groq API with selected models.
+    # Available models: llama3-8b-8192, llama3-70b-8192, llama2-70b-4096, mixtral-8x7b-32768, gemma-7b-it
+    def __init__(
+            self,
+            model: str = "llama3-70b-8192",
+            api_key: str = os.getenv("GROQ_API_KEY"),
+    ):
+        if api_key is None:
+            raise ValueError("GROQ_API_KEY environment variable is not set")
+
+        super().__init__(
+            model=model,
+            api_key=api_key,
+        )

--- a/examples/configurations/api/groq_api.py
+++ b/examples/configurations/api/groq_api.py
@@ -2,7 +2,7 @@ import os
 from llama_index.llms.groq import Groq
 
 
-class GroqApiLLM(Groq):
+class LLM(Groq):
     # This class initializes the Groq API with selected models.
     # Available models: llama3-8b-8192, llama3-70b-8192, llama2-70b-4096, mixtral-8x7b-32768, gemma-7b-it
     def __init__(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,8 @@ dependencies = [
   "llama-index-llms-azure-openai==0.1.5",
   "llama-index-llms-litellm==0.1.4",
   "llama-index-llms-openai==0.1.9",
+  "llama-index-llms-anthropic==0.1.8",
+  "llama-index-llms-groq==0.1.3",
   "llama-index-multi-modal-llms-openai==0.1.4",
   "llama-index-program-openai==0.1.4",
   "llama-index-question-gen-openai==0.1.3",


### PR DESCRIPTION
I have updated the Groq and Anthropic model configurations to the LaVague project's current format using external Python configuration files. This update ensures that the implementation remains flexible and can be modified by external users, while adhering to the standards specified in the LaVague project requirements.

Summary of Changes:

* Groq API: I have included configurations for models such as llama3-8b-8192, llama3-70b-8192, llama2-70b-4096, mixtral-8x7b-32768, and gemma-7b-it in external Python configuration files. ***Notably, the llama-3 model, announced on April 18, 2023, is now accessible through the Groq API.***
* Anthropic API: Similarly to the Groq API, I have made configurations for the claude-3-haiku-20240307, claude-3-sonnet-20240229, claude-3-opus-20240229 accessible via separate Python configuration files, allowing users to easily update and modify settings.