### PR TITLE
🚀 Playwright support in Gradio launch

### DIFF
--- a/src/lavague/cli/commands.py
+++ b/src/lavague/cli/commands.py
@@ -25,8 +25,10 @@ def launch(ctx):
     else:
         instructions = Instructions.from_default()
     action_engine = config.make_action_engine()
-    driver = config.get_driver()
-    command_center = GradioDemo(action_engine, driver)
+    # We will just pass the get driver func name to the Gradio demo.
+    # We will call this during driver initialization in init_driver() 
+    get_driver = config.get_driver
+    command_center = GradioDemo(action_engine, get_driver)
     command_center.run(instructions.url, instructions.instructions)
 
 

--- a/src/lavague/cli/commands.py
+++ b/src/lavague/cli/commands.py
@@ -87,7 +87,7 @@ def build(ctx, output_file: Optional[str], test: bool = False):
     output = "\n".join(source_code_lines)
     output += f"\n{abstractDriver.goToUrlCode(instructions.url.strip())}\n"
     driver_name, driver = abstractDriver.getDriver()
-    exec(f"{driver_name} = driver")  # define driver
+    exec(f"{driver_name.strip()} = driver")  # define driver
 
     for instruction in tqdm(instructions.instructions):
         print(f"Processing instruction: {instruction}")

--- a/src/lavague/command_center.py
+++ b/src/lavague/command_center.py
@@ -40,15 +40,17 @@ class GradioDemo(CommandCenter):
     </div>
     """
 
-    def __init__(self, actionEngine: ActionEngine, driver: AbstractDriver):
+    def __init__(self, actionEngine: ActionEngine, get_driver: callable):
         self.actionEngine = actionEngine
-        self.driver = driver
+        self.get_driver = get_driver
+        self.driver = None
         self.base_url = ""
         self.success = False
         self.error = ""
 
     def init_driver(self):
         def init_driver_impl(url):
+            self.driver = self.get_driver() if self.driver is None else self.driver
             self.driver.goTo(url)
             self.driver.getScreenshot("screenshot.png")
             # This function is supposed to fetch and return the image from the URL.

--- a/src/lavague/command_center.py
+++ b/src/lavague/command_center.py
@@ -103,7 +103,8 @@ class GradioDemo(CommandCenter):
             self.error = ""
             code = self.actionEngine.cleaning_function(code)
             html = self.driver.getHtml()
-            _, driver = self.driver.getDriver()  # define driver for exec
+            driver_name, driver = self.driver.getDriver()  # define driver for exec
+            exec(f"{driver_name.strip()} = driver")  # define driver in case its name is different
             try:
                 exec(code)
                 output = "Successful code execution"
@@ -193,6 +194,10 @@ class GradioDemo(CommandCenter):
             )
             text_area.submit(
                 self.__show_processing_message(), outputs=[status_html]
+            ).then(
+                self.init_driver(),
+                inputs=[url_input],
+                outputs=[image_display],
             ).then(
                 self.process_instructions(),
                 inputs=[text_area, url_input],


### PR DESCRIPTION
Read more about the issue on #186 
Closes #186 
Now you can do 🚀 
`!lavague -c examples/configurations/api/openai_api_playwright.py launch`

What was the issue: I found that if you have called the playwright driver before launching the gradio demo then both the browser and gradio runs on different threads and so when you try to hit page.goto(someurl.com) from gradio. It throws an error: can't switch thread as you are trying to do that.
Solution was very simple 😆 : Call get_driver only after gradio launch which is inside the init_driver method. That's it.
This will work perfectly fine with Selenium and Playwright or any other Integrations.
