### PR TITLE
fix: cell execution order in quick-tour.ipynb to fix OpenAI key error

### DIFF
--- a/docs/docs/get-started/quick-tour-notebook/quick-tour.ipynb
+++ b/docs/docs/get-started/quick-tour-notebook/quick-tour.ipynb
@@ -73,6 +73,27 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will need to set our OpenAI Key as a Colab secret (see the key icon on the left-hand side of the Colab notebook) named 'OPENAI_API_KEY' and then convert it to an environment variable with the same name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "szM8iq3LINtq"
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from google.colab import userdata\n",
+    "\n",
+    "os.environ[\"OPENAI_API_KEY\"] = userdata.get('OPENAI_API_KEY')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "id": "GhHF9m4zd8mJ"
    },
@@ -102,27 +123,6 @@
     "\n",
     "retriever = OpsmSplitRetriever(embedder, top_k=3)\n",
     "action_engine = ActionEngine(llm, retriever)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We will finally need to define our `OPENAI_API_KEY`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "id": "szM8iq3LINtq"
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "from google.colab import userdata\n",
-    "\n",
-    "os.environ[\"OPENAI_API_KEY\"] = userdata.get('OPENAI_API_KEY')"
    ]
   },
   {


### PR DESCRIPTION
In the Quick Tour notebook (quick-tour.ipynb), setting the key for OpenAI needs to take place before creating the underlying resources for the ActionEngine, otherwise an error will be thrown as seen below:

![key_error](https://github.com/lavague-ai/LaVague/assets/26125306/052d74d3-c9c6-4aab-9c1b-4e0fd3b1f3df)

I've simply moved the setting of the OpenAI key so that it happens immediately before this cell, and cleaned up the verbiage in the description of the cell. Also cleaned up pip install output from cell 1.