### PR TITLE
Fix telemetry error with local variable 't' referenced before assignment

### DIFF
--- a/lavague-core/lavague/core/utilities/telemetry.py
+++ b/lavague-core/lavague/core/utilities/telemetry.py
@@ -41,7 +41,7 @@ def send_telemetry(logger_telemetry: DataFrame, test: bool = False):
                     "lavague-core"
                 )
 
-                if "engine_log" in t:
+                if "engine_log" in row:
                     t = row["engine_log"]
                     if t is not None:
                         if isinstance(t, list):


### PR DESCRIPTION
The Telemetry module is currently failing due to the use of the engine_log variable before it is assigned. The root cause of this issue is a typo where the existence of `engine_log` should be checked from row instead of `t`.

Error was : `Telemetry failed with local variable 't' referenced before assignment`