### PR TITLE
fix: update regular expression in extract_and_eval function

### DIFF
--- a/lavague-core/lavague/core/utilities/format_utils.py
+++ b/lavague-core/lavague/core/utilities/format_utils.py
@@ -116,7 +116,7 @@ def extract_next_engine(text):
 
 def extract_and_eval(string):
     # Regular expression to match a list inside a string
-    match = re.search(r"\[.*?\]", string, re.DOTALL)
+    match = re.search(r"\[.*\]", string, re.DOTALL)
     if match:
         list_string = match.group(0)
         try:

--- a/tests/lavague-core/lavague/core/utilities/test_format_utils.py
+++ b/tests/lavague-core/lavague/core/utilities/test_format_utils.py
@@ -1,0 +1,16 @@
+import unittest
+from lavague.core.utilities.format_utils import extract_and_eval
+
+class TestFormatUtils(unittest.TestCase):
+
+    def test_extract_and_eval(self):
+        self.assertEqual(extract_and_eval("""[{'query':'#root', 'action':'Click on the root element'}]"""),
+                         [{'query':'#root', 'action':'Click on the root element'}])
+        self.assertEqual(extract_and_eval("""[{'query':'img[data-testid="lang-switch"]', 'action':'Click on the image with the `data-testid` attribute equal to `lang-switch`'}]"""),
+                         [{'query':'img[data-testid="lang-switch"]', 'action':'Click on the image with the `data-testid` attribute equal to `lang-switch`'}])
+        self.assertEqual(extract_and_eval("""[{'query':'img[data-testid="lang-switch"]', 'action':'Click on the image with the `data-testid` attribute equal to `lang-switch`'}, {'query':'img[data-testid="lang-switch2"]', 'action':'Click on the image with the `data-testid` attribute equal to `lang-switch2`'}]"""),
+                         [{'query':'img[data-testid="lang-switch"]', 'action':'Click on the image with the `data-testid` attribute equal to `lang-switch`'},
+                          {'query':'img[data-testid="lang-switch2"]', 'action':'Click on the image with the `data-testid` attribute equal to `lang-switch2`'}])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
To address issue [Got error "TypeError: string indices must be integers, not 'str'" when llm response contain []](https://github.com/lavague-ai/LaVague/issues/320)