### PR TITLE
Add LocalLogger class for logging to a local file

### DIFF
--- a/lavague-core/lavague/core/agents.py
+++ b/lavague-core/lavague/core/agents.py
@@ -37,6 +37,7 @@ class WebAgent:
         action_engine: ActionEngine,
         n_steps: int = 10,
         clean_screenshot_folder: bool = True,
+        logger: AgentLogger = None,
     ):
         self.driver: BaseDriver = action_engine.driver
         self.action_engine: ActionEngine = action_engine
@@ -49,7 +50,10 @@ class WebAgent:
 
         self.clean_screenshot_folder = clean_screenshot_folder
 
-        self.logger: AgentLogger = AgentLogger()
+        if logger is None:
+            self.logger: AgentLogger = AgentLogger()
+        else:
+            self.logger = logger
 
         self.action_engine.set_logger_all(self.logger)
         self.world_model.set_logger(self.logger)

--- a/lavague-core/lavague/core/logger.py
+++ b/lavague-core/lavague/core/logger.py
@@ -2,6 +2,7 @@ import uuid
 import pandas as pd
 import os
 from PIL import Image
+import json
 
 
 def load_images_from_folder(folder_path):
@@ -49,6 +50,45 @@ class AgentLogger:
         df = pd.DataFrame(self.logs)
         df["screenshots"] = df["screenshots_path"].apply(load_images_from_folder)
         return df
+    
+class LocalLogger(AgentLogger):
+    def __init__(self, log_file_path: str, ignore_keys:list[str] = None):
+        self.log_file_path = log_file_path
+        self.ignore_keys = ignore_keys
+        if self.ignore_keys is None:
+            self.ignore_keys = ["screenshots", "html"]
+        super().__init__()
+        with open(self.log_file_path, 'w') as f:
+            f.write('')
+
+    def clear_logs(self):
+        super().clear_logs()
+        # Clear the log file
+        with open(self.log_file_path, 'w') as f:
+            f.write('')
+
+    def add_log(self, log: dict):
+        super().add_log(log)
+        # Write the log to the file
+        with open(self.log_file_path, 'a') as f:
+            f.write(self.serialize_dict(log))
+            f.write('\n')  # Ensure each log entry is on a new line
+
+    # Custom function to serialize non-serializable objects
+    def custom_serializer(self, obj):
+        if isinstance(obj, dict):
+            return {k: self.custom_serializer(v) for k, v in obj.items() if k not in self.ignore_keys}
+        elif isinstance(obj, list):
+            return [self.custom_serializer(v) for v in obj]
+        try:
+            json.dumps(obj)
+            return obj
+        except (TypeError, OverflowError):
+            return None
+
+    # Function to serialize dictionary with ignoring non-serializable properties
+    def serialize_dict(self, input_dict):
+        return json.dumps(self.custom_serializer(input_dict))
 
 
 class Loggable:


### PR DESCRIPTION
This PR aiming to address issue [Save logs locally #288](https://github.com/lavague-ai/LaVague/issues/288)

By adding LocalLogger class that inherit AgentLogger

Usage:
- import LocalLogger module
```python
from lavague.core.logger import LocalLogger
```
- Create LocalLogger instance for web agent and world model
```python
    web_agent_local_logger = LocalLogger("web_agent_logs.json")
    world_model_local_logger = LocalLogger("world_agent_logs.json")
    driver = SeleniumDriver(headless=False)
    world_model = WorldModel()
    action_engine = ActionEngine(driver)
    agent = WebAgent(world_model, action_engine)
    agent.action_engine.set_logger_all(web_agent_local_logger)
    agent.world_model.set_logger(world_model_local_logger)
```