### PR TITLE
Feature/tokencounter

### DIFF
--- a/lavague-core/lavague/core/agents.py
+++ b/lavague-core/lavague/core/agents.py
@@ -81,8 +81,8 @@ class WebAgent:
             output=None,
         )
 
-        self.mm_llm_token_counter = token_counter.get("llm_token_counter", None)
-        self.embedding_token_counter = token_counter.get("embedding_token_counter", None)
+        self.mm_llm_token_counter = token_counter.get("llm_token_counter", None) if token_counter else None
+        self.embedding_token_counter = token_counter.get("embedding_token_counter", None) if token_counter else None
 
     def get(self, url):
         self.driver.get(url)

--- a/lavague-core/lavague/core/token_counter_init.py
+++ b/lavague-core/lavague/core/token_counter_init.py
@@ -1,0 +1,21 @@
+import tiktoken
+from llama_index.core.callbacks.schema import CBEventType
+from llama_index.core.callbacks import CallbackManager, TokenCountingHandler
+from llama_index.core import Settings
+
+def init_token_counter():
+    """
+    Initializing two token counters for each of 'gpt-4o' and 'text-embedding-3-large' models
+    """
+    mm_llm_token_counter = TokenCountingHandler(
+        tokenizer=tiktoken.encoding_for_model("gpt-4o").encode,
+        event_starts_to_ignore=[CBEventType.EMBEDDING],
+        event_ends_to_ignore=[CBEventType.EMBEDDING],
+    )
+    embedding_token_counter = TokenCountingHandler(
+        tokenizer=tiktoken.encoding_for_model("text-embedding-3-large").encode,
+        event_starts_to_ignore=[CBEventType.LLM],
+        event_ends_to_ignore=[CBEventType.LLM],
+    )
+    Settings.callback_manager = CallbackManager([mm_llm_token_counter, embedding_token_counter])
+    return {"llm_token_counter" : mm_llm_token_counter, "embedding_token_counter" : embedding_token_counter}


### PR DESCRIPTION
* Added token counting callbacks for each of  'gpt-4o' and 'text-embedding-3-large'.

* Added these separately to address the proper counting of tokens on each event's callback.

* The counts are calculated per each step of agentic run.

* 'init_token_counter' method of lavague-core/lavague/core/token_counter_init.py
must be called at the start of application and it returns a dictionary, of llm token counter and
embedding token counter, that must be passed to agent upon initialization
for token counting to show up on logs else they will be shown as 0.

* The token counts are measured by the [tiktoken](https://github.com/openai/tiktoken), a BPE tokeniser for openAI models.
My observation is this process gives us accurate but not precise token counts. 
The actual precise token consumption counts are provided by an usage attribute in each openai api request.
To get precise measurements, there are ways to make use of usage attribute for llm request but for embedding request, as of now,
it is a bit complex.
But I think current readings are accurate enough.


