### PR TITLE
Agent test tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ env/
 venv/
 
 tests/*.py
+tests/*.ipynb

--- a/lavague-core/lavague/core/agents.py
+++ b/lavague-core/lavague/core/agents.py
@@ -324,6 +324,7 @@ class WebAgent:
         step_by_step=False,
     ) -> ActionResult:
         self.action_engine.set_display_all(display)
+
         try:
             if user_data:
                 self.st_memory.set_user_data(user_data)

--- a/lavague-core/lavague/core/base_driver.py
+++ b/lavague-core/lavague/core/base_driver.py
@@ -1,6 +1,8 @@
+from PIL import Image
 import os
 from pathlib import Path
-from typing import Any, Callable, Optional, Mapping, Dict, Set
+import re
+from typing import Any, Callable, Optional, Mapping, Dict, Set, List, Union
 from abc import ABC, abstractmethod
 from lavague.core.utilities.format_utils import (
     extract_code_from_funct,
@@ -20,6 +22,8 @@ class InteractionType(Enum):
 
 
 PossibleInteractionsByXpath = Dict[str, Set[InteractionType]]
+
+r_get_xpaths_from_html = r'xpath=["\'](.*?)["\']'
 
 
 class BaseDriver(ABC):
@@ -300,35 +304,98 @@ class BaseDriver(ABC):
     def get_screenshot_as_png(self) -> bytes:
         pass
 
+    def get_nodes(self, xpaths: List[str]) -> List["DOMNode"]:
+        raise NotImplementedError("get_nodes not implemented")
+
+    def get_nodes_from_html(self, html: str) -> List["DOMNode"]:
+        return self.get_nodes(re.findall(r_get_xpaths_from_html, html))
+
+    def highlight_node_from_xpath(self, xpath: str, color: str = "red") -> Callable:
+        return self.highlight_nodes([xpath], color)
+
+    def highlight_nodes(self, xpaths: List[str], color: str = "red") -> Callable:
+        nodes = [n.highlight(color) for n in self.get_nodes(xpaths)]
+        return self._add_highlighted_destructors(lambda: [n.clear() for n in nodes])
+
+    def highlight_nodes_from_html(self, html: str, color: str = "blue") -> Callable:
+        return self.highlight_nodes(re.findall(r_get_xpaths_from_html, html), color)
+
+    def remove_highlight(self):
+        if hasattr(self, "_highlight_destructors"):
+            for destructor in self._highlight_destructors:
+                destructor()
+            delattr(self, "_highlight_destructors")
+
+    def _add_highlighted_destructors(
+        self, destructors: Union[List[Callable], Callable]
+    ):
+        if not hasattr(self, "_highlight_destructors"):
+            self._highlight_destructors = []
+        if isinstance(destructors, Callable):
+            self._highlight_destructors.append(destructors)
+        else:
+            self._highlight_destructors.extend(destructors)
+        return destructors
+
+    def highlight_interactive_nodes(
+        self, *with_interactions: tuple[InteractionType], color: str = "red"
+    ):
+        if with_interactions is None or len(with_interactions) == 0:
+            return self.highlight_nodes(
+                list(self.get_possible_interactions().keys()), color
+            )
+
+        return self.highlight_nodes(
+            [
+                xpath
+                for xpath, interactions in self.get_possible_interactions().items()
+                if set(interactions) & set(with_interactions)
+            ],
+            color,
+        )
+
+
+class DOMNode(ABC):
     @abstractmethod
-    def resolve_xpath(self, xpath: str):
+    def highlight(self, color: str = "red"):
         pass
+
+    @abstractmethod
+    def clear(self):
+        return self
+
+    @abstractmethod
+    def take_screenshot(self) -> Image:
+        pass
+
+    def __str__(self) -> str:
+        return self.get_html()
 
 
 JS_SETUP_GET_EVENTS = """
 (function() {
-  const targetProto = EventTarget.prototype;
-  targetProto._addEventListener = Element.prototype.addEventListener;
-  targetProto.addEventListener = function(a,b,c) {
-    this._addEventListener(a,b,c);
-    if(!this.eventListenerList) this.eventListenerList = {};
-    if(!this.eventListenerList[a]) this.eventListenerList[a] = [];
-    this.eventListenerList[a].push(b);
-  };
-  targetProto._removeEventListener = Element.prototype.removeEventListener;
-  targetProto.removeEventListener = function(a, b, c) {
-    this._removeEventListener(a, b, c);
-    if(this.eventListenerList && this.eventListenerList[a]) {
-      const index = this.eventListenerList[a].indexOf(b);
-      if (index > -1) {
-        this.eventListenerList[a].splice(index, 1);
-        if(!this.eventListenerList[a].length) {
-          delete this.eventListenerList[a];
+  if (window && !window.getEventListeners) {
+    const targetProto = EventTarget.prototype;
+    targetProto._addEventListener = Element.prototype.addEventListener;
+    targetProto.addEventListener = function(a,b,c) {
+        this._addEventListener(a,b,c);
+        if(!this.eventListenerList) this.eventListenerList = {};
+        if(!this.eventListenerList[a]) this.eventListenerList[a] = [];
+        this.eventListenerList[a].push(b);
+    };
+    targetProto._removeEventListener = Element.prototype.removeEventListener;
+    targetProto.removeEventListener = function(a, b, c) {
+        this._removeEventListener(a, b, c);
+        if(this.eventListenerList && this.eventListenerList[a]) {
+        const index = this.eventListenerList[a].indexOf(b);
+        if (index > -1) {
+            this.eventListenerList[a].splice(index, 1);
+            if(!this.eventListenerList[a].length) {
+            delete this.eventListenerList[a];
+            }
         }
-      }
-    }
-  };
-  if (!window.getEventListeners) {
+        }
+    };
     window.getEventListeners = function(e) {
       return (e && e.eventListenerList) || [];
     }
@@ -343,11 +410,11 @@ return (function() {
           || e.getAttribute('aria-disabled') === 'true' || (tag === 'input' && e.getAttribute('type') === 'hidden')) {
             return [];
         }
-        const style = getComputedStyle(e);
+        const style = getComputedStyle(e) || {};
         if (style.display === 'none' || style.visibility === 'hidden' || style.opacity === '0') {
             return [];
         }
-        const events = getEventListeners(e);
+        const events = window && typeof window.getEventListeners === 'function' ? window.getEventListeners(e) : [];
         const role = e.getAttribute('role');
         const clickableInputs = ['submit', 'checkbox', 'radio', 'color', 'file', 'image', 'reset'];
         function hasEvent(n) {
@@ -382,7 +449,11 @@ return (function() {
         }
         const countByTag = {};
         for (let child = node.firstChild; child; child = child.nextSibling) {
-            const tag = child.nodeName.toLowerCase();
+            let tag = child.nodeName.toLowerCase();
+            let isLocal = ['svg'].includes(tag);
+            if (isLocal) {
+                tag = `*[local-name() = '${tag}']`;
+            }
             countByTag[tag] = (countByTag[tag] || 0) + 1;
             let childXpath = xpath + '/' + tag;
             if (countByTag[tag] > 1) {
@@ -394,7 +465,7 @@ return (function() {
                 } catch (e) {
                     console.error("iframe access blocked", child, e);
                 }
-            } else {
+            } else if (!isLocal) {
                 traverse(child, childXpath);
             } 
         }

--- a/lavague-core/lavague/core/retrievers.py
+++ b/lavague-core/lavague/core/retrievers.py
@@ -279,14 +279,17 @@ class IxpathRetriever(BaseHtmlRetriever):
             siblings = [
                 sib for sib in element.parent.children if sib.name == element.name
             ]
+            tag = element.name
+            if tag in ["svg", "path", "circle", "g"]:
+                tag = f"*[local-name() = '{tag}']"
             if len(siblings) > 1:
                 count = siblings.index(element) + 1
                 if count == 1:
-                    path = f"/{element.name}{path}"
+                    path = f"/{tag}{path}"
                 else:
-                    path = f"/{element.name}[{count}]{path}"
+                    path = f"/{tag}[{count}]{path}"
             else:
-                path = f"/{element.name}{path}"
+                path = f"/{tag}{path}"
             return self._generate_xpath(element.parent, path)
 
     def _add_xpath_attributes(

--- a/lavague-integrations/drivers/lavague-drivers-selenium/lavague/drivers/selenium/base.py
+++ b/lavague-integrations/drivers/lavague-drivers-selenium/lavague/drivers/selenium/base.py
@@ -29,6 +29,7 @@ class SeleniumDriver(BaseDriver):
         height: int = 1080,
         no_load_strategy: bool = False,
         options: Optional[Options] = None,
+        driver: Optional[WebDriver] = None,
     ):
         self.headless = headless
         self.user_data_dir = user_data_dir
@@ -36,6 +37,7 @@ class SeleniumDriver(BaseDriver):
         self.height = height
         self.no_load_strategy = no_load_strategy
         self.options = options
+        self.driver = driver
         super().__init__(url, get_selenium_driver)
 
     #   Default code to init the driver.
@@ -68,7 +70,8 @@ class SeleniumDriver(BaseDriver):
         chrome_options.add_argument("--disable-site-isolation-trials")
         chrome_options.add_argument("--disable-notifications")
 
-        self.driver = webdriver.Chrome(options=chrome_options)
+        if self.driver is None:
+            self.driver = webdriver.Chrome(options=chrome_options)
         self.driver.execute_cdp_cmd(
             "Page.addScriptToEvaluateOnNewDocument",
             {"source": JS_SETUP_GET_EVENTS},

--- a/lavague-tests/README.md
+++ b/lavague-tests/README.md
@@ -33,8 +33,51 @@ lavague-tests/sites/
     └── config.yml
 ```
 
-Example config.yml
-The config.yml file should define tasks with the following structure:
+The config.yml file define tasks with the following structure:
+
+```yaml
+type: web
+max_steps: 5                      # max number of action engine retry
+n_attempts: 1                     # max number of agent retry
+user_data:                        # optional user data to feed the Agent
+  key: value
+tasks:
+  - name: Name                    # Optional display name
+    max_steps: 5                  # to override global value
+    n_attempts: 1                 # to override global value
+    url: https://example.com      # the intial task URL
+    prompt: Prompt for the agent  # the agent prompt
+    expect:                       # the list of tests to perform on task completion, see below for details
+      - <property> <operator> <value>
+    user_data:                    # optional task-scoped user data to feed the Agent
+      key: value
+```
+
+
+### Available operators:
+
+| Operator          | Python operation      |
+|-------------------|-----------------------|
+| is                | operator.eq           |
+| is not            | operator.ne           |
+| is lower than     | operator.lt           |
+| is greater than   | operator.gt           |
+| contains          | operator.contains     |
+| does not contain  | not operator.contains |
+
+
+### Available properties:
+
+| Property | Type              |
+|----------|-------------------|
+| URL      | string            |
+| Status   | success / failure |
+| Output   | string            |
+| Steps    | number            |
+| HTML     | string            |
+| Tabs     | string            |
+
+Example of `config.yml`
 
 ```yaml
 tasks:
@@ -52,3 +95,44 @@ tasks:
       - URL is https://huggingface.co/datasets/BigAction/the-wave-250
       - Status is success
 ```
+
+
+## Output
+
+`lavague-test` will output a report with successes and failures.
+If all tests passed exit code will be 0, and -1 if at least one test failed.
+
+Example:
+```text
+[o] HuggingFace navigation
+        URL is https://huggingface.co/docs/peft/quicktour
+        Status is success
+        HTML contains PEFT offers parameter-efficient methods for finetuning large pretrained models
+
+[o] HuggingFace search
+        URL is https://huggingface.co/datasets/BigAction/the-wave-250
+        Status is success
+
+[x] Go to LaVague.ai from https://google.com
+    (x) URL is https://lavague.ai - was: https://www.google.com/
+    (x) Status is success - was: failure
+
+[o] Navigate using link
+        URL is http://localhost:8000/menu.html
+        Status is success
+        HTML contains <h1>Menu</h1>
+
+Result: 80 % (8 / 10)
+```
+
+## Use with static local website
+
+In `config.yml` set `type` to `static` to serve a static website locally.
+
+The following options are available:
+- directory : the directory to serve files from. Defaults to `www` ;
+- port : the port to serve the files on. Defaults to 8000.
+
+## Use with dynamic local website
+
+Initialization command for local websites will be available soon.

--- a/lavague-tests/README.md
+++ b/lavague-tests/README.md
@@ -1,0 +1,1 @@
+# Test runner for LaVague

--- a/lavague-tests/README.md
+++ b/lavague-tests/README.md
@@ -1,1 +1,54 @@
 # Test runner for LaVague
+
+LaVague Test Runner is a tool designed to run tests on real websites and generate comprehensive reports. It can be easily launched using the lavague-test command.
+
+## Usage
+
+To run the LaVague Test Runner, use the lavague-test command. Below are the available options and their descriptions:
+
+### Command Options
+
+- --directory / -d
+  - Default: current working directory + "/lavague-tests/sites"
+  - Type: str
+  - Description: Specifies the directory where the site test files are located.
+
+- --site / -s
+  - Default: test on all sites described in -d directory
+  - Type: str
+  - Description: Specifies the site names to run tests on. This option can be used multiple times to specify multiple sites.
+
+- --display
+  - Type: flag
+  - Description: If set, the browser will be displayed during the tests.
+
+
+### Site Test Folder Structure
+
+Each site to be tested must be a folder containing a `config.yml` file with the test configuration. Below is an example structure:
+
+```arduino
+lavague-tests/sites/
+└── example-site/
+    └── config.yml
+```
+
+Example config.yml
+The config.yml file should define tasks with the following structure:
+
+```yaml
+tasks:
+  - name: HuggingFace navigation
+    url: https://huggingface.co/docs
+    prompt: Go on the quicktour of PEFT
+    expect:
+      - URL is https://huggingface.co/docs/peft/quicktour
+      - Status is success
+      - HTML contains PEFT offers parameter-efficient methods for finetuning large pretrained models
+  - name: HuggingFace search
+    url: https://huggingface.co
+    prompt: Find the-wave-250 dataset
+    expect:
+      - URL is https://huggingface.co/datasets/BigAction/the-wave-250
+      - Status is success
+```

--- a/lavague-tests/lavague/tests/cli.py
+++ b/lavague-tests/lavague/tests/cli.py
@@ -23,7 +23,12 @@ from .runner import TestRunner
     multiple=True,
     help="site name",
 )
-def cli(directory: str, site: List[str]) -> None:
+@click.option(
+    "--display",
+    is_flag=True,
+    help="if set browser will be displayed",
+)
+def cli(directory: str, site: List[str], display: bool) -> None:
     sites_to_test: List[Path] = []
     try:
         for item in os.listdir(directory):
@@ -35,11 +40,14 @@ def cli(directory: str, site: List[str]) -> None:
                     sites_to_test.append(config)
                 except Exception as e:
                     click.echo(f"Invalid site config '{item}': {e}")
+                    raise e
     except FileNotFoundError:
         click.echo(f"Directory '{directory}' not found.")
 
-    runner = TestRunner(sites=sites_to_test)
-    runner.run()
+    runner = TestRunner(sites=sites_to_test, headless=not display)
+    res = runner.run()
+    print(str(res))
+    exit(0 if res.is_success() else -1)
 
 
 if __name__ == "__main__":

--- a/lavague-tests/lavague/tests/cli.py
+++ b/lavague-tests/lavague/tests/cli.py
@@ -1,0 +1,46 @@
+import click
+import os
+from pathlib import Path
+from typing import List
+from .config import TestConfig
+from .runner import TestRunner
+
+
+@click.command()
+@click.option(
+    "--directory",
+    "-d",
+    default=os.getcwd() + "/lavague-tests/sites",
+    type=str,
+    required=False,
+    help="sites directory",
+)
+@click.option(
+    "--site",
+    "-s",
+    type=str,
+    required=False,
+    multiple=True,
+    help="site name",
+)
+def cli(directory: str, site: List[str]) -> None:
+    sites_to_test: List[Path] = []
+    try:
+        for item in os.listdir(directory):
+            if (len(site) == 0 or item in site) and os.path.isfile(
+                os.path.join(directory, item, "config.yml")
+            ):
+                try:
+                    config = TestConfig(os.path.join(directory, item))
+                    sites_to_test.append(config)
+                except Exception as e:
+                    click.echo(f"Invalid site config '{item}': {e}")
+    except FileNotFoundError:
+        click.echo(f"Directory '{directory}' not found.")
+
+    runner = TestRunner(sites=sites_to_test)
+    runner.run()
+
+
+if __name__ == "__main__":
+    cli()

--- a/lavague-tests/lavague/tests/config.py
+++ b/lavague-tests/lavague/tests/config.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import Any, List, Dict
 import yaml
 from .setup import Setup
 from .test import ExpectTest, TaskTest
@@ -6,13 +6,22 @@ from .test import ExpectTest, TaskTest
 
 class Task:
     def __init__(
-        self, name: str, url: str, prompt: str, max_steps: int, tests: List[TaskTest]
+        self,
+        name: str,
+        url: str,
+        prompt: str,
+        max_steps: int,
+        tests: List[TaskTest],
+        user_data: Dict,
+        n_attempts: int,
     ):
         self.name = name
         self.url = url
         self.prompt = prompt
         self.max_steps = max_steps
         self.tests = tests
+        self.user_data = user_data
+        self.n_attempts = n_attempts
 
     def __str__(self) -> str:
         return f"Task(name={self.name}, url={self.url}, prompt={self.prompt}, tests={len(self.tests)})"
@@ -30,12 +39,18 @@ class TestConfig:
             for task_data in data["tasks"]:
                 prompt = task_data["prompt"]
                 url = task_data.get("url", self.setup.default_url)
+                user_data = {
+                    **data.get("user_data", {}),
+                    **task_data.get("user_data", {}),
+                }
                 task = Task(
                     task_data.get("name", f"{prompt} from {url}"),
                     url,
                     prompt,
-                    task_data.get("max_steps", 10),
+                    task_data.get("max_steps", data.get("max_steps", 5)),
                     self._parse_test(task_data),
+                    user_data,
+                    task_data.get("n_attempts", data.get("n_attempts", 1)),
                 )
                 self.tasks.append(task)
 

--- a/lavague-tests/lavague/tests/config.py
+++ b/lavague-tests/lavague/tests/config.py
@@ -33,26 +33,31 @@ class TestConfig:
     def __init__(self, directory: str):
         self.directory = directory
         self.tasks: list[Task] = []
+
         with open(f"{directory}/config.yml", "r") as f:
-            data = yaml.safe_load(f)
-            self.setup = Setup.parse(directory, data)
-            for task_data in data["tasks"]:
-                prompt = task_data["prompt"]
-                url = task_data.get("url", self.setup.default_url)
-                user_data = {
-                    **data.get("user_data", {}),
-                    **task_data.get("user_data", {}),
-                }
-                task = Task(
-                    task_data.get("name", f"{prompt} from {url}"),
-                    url,
-                    prompt,
-                    task_data.get("max_steps", data.get("max_steps", 5)),
-                    self._parse_test(task_data),
-                    user_data,
-                    task_data.get("n_attempts", data.get("n_attempts", 1)),
-                )
-                self.tasks.append(task)
+            self.data = yaml.safe_load(f)
+            self.setup = Setup.parse(directory, self.data)
+
+            for task_data in self.data["tasks"]:
+                self.read_task(task_data)
+
+    def read_task(self, task_data: Dict):
+        prompt = task_data["prompt"]
+        url = task_data.get("url", self.setup.default_url)
+        user_data = {
+            **self.data.get("user_data", {}),
+            **task_data.get("user_data", {}),
+        }
+        task = Task(
+            task_data.get("name", f"{prompt} from {url}"),
+            url,
+            prompt,
+            task_data.get("max_steps", self.data.get("max_steps", 5)),
+            self._parse_test(task_data),
+            user_data,
+            task_data.get("n_attempts", self.data.get("n_attempts", 1)),
+        )
+        self.tasks.append(task)
 
     def __str__(self) -> str:
         return "\n".join([str(t) for t in self.tasks])

--- a/lavague-tests/lavague/tests/config.py
+++ b/lavague-tests/lavague/tests/config.py
@@ -1,0 +1,43 @@
+from typing import Any, List
+import yaml
+from .setup import Setup
+from .test import ExpectTest, TaskTest
+
+
+class Task:
+    def __init__(self, url: str, prompt: str, tests: List[TaskTest]):
+        self.url = url
+        self.prompt = prompt
+        self.tests = tests
+
+    def __str__(self) -> str:
+        return f"Task(url={self.url}, prompt={self.prompt}, tests={len(self.tests)})"
+
+
+class TestConfig:
+    setup: Setup
+    tasks: list[Task] = []
+
+    def __init__(self, directory: str):
+        self.directory = directory
+        with open(f"{directory}/config.yml", "r") as f:
+            data = yaml.safe_load(f)
+            self.setup = Setup.parse(data)
+            for task_data in data["tasks"]:
+                task = Task(
+                    task_data.get("url", self.setup.default_url),
+                    task_data["prompt"],
+                    self._parse_test(task_data),
+                )
+                self.tasks.append(task)
+
+    def __str__(self) -> str:
+        return "\n".join([str(t) for t in self.tasks])
+
+    def _parse_test(self, task_data: Any) -> List[TaskTest]:
+        tests: List[TaskTest] = []
+
+        if "expect" in task_data:
+            tests += ExpectTest.parse(task_data["expect"])
+
+        return tests

--- a/lavague-tests/lavague/tests/runner.py
+++ b/lavague-tests/lavague/tests/runner.py
@@ -3,6 +3,7 @@ from lavague.core.agents import WebAgent
 from lavague.core.world_model import WorldModel
 from lavague.core.action_engine import ActionEngine
 from lavague.drivers.selenium.base import SeleniumDriver
+from .util import HiddenPrints
 from .config import Task, TestConfig, TaskTest
 from pandas import DataFrame
 
@@ -129,6 +130,7 @@ class TestRunner:
             "Output": agent.result.output,
             "Steps": agent.logger.current_step,
             "HTML": agent.driver.get_html(),
+            "Tabs": agent.driver.get_tabs(),
         }
 
     def __str__(self) -> str:

--- a/lavague-tests/lavague/tests/runner.py
+++ b/lavague-tests/lavague/tests/runner.py
@@ -3,49 +3,132 @@ from lavague.core.agents import WebAgent
 from lavague.core.world_model import WorldModel
 from lavague.core.action_engine import ActionEngine
 from lavague.drivers.selenium.base import SeleniumDriver
-from .config import Task, TestConfig
+from .config import Task, TestConfig, TaskTest
+from pandas import DataFrame
 
 
-class RunResult:
-    success: int
+class TestFailure:
+    def __init__(self, test: TaskTest, message: str):
+        self.test = test
+        self.message = message
+
+    def __str__(self) -> str:
+        return f"{self.test} - {self.message}"
+
+
+class SingleRunResult:
+    def __init__(self, task: Task, dataframe: DataFrame):
+        self.successes: List[TaskTest] = []
+        self.failures: List[TestFailure] = []
+        self.task = task
+        self.dataframe = dataframe
+
+    def get_test_count(self) -> int:
+        return len(self.successes) + len(self.failures)
+
+    def __str__(self) -> str:
+        success = "o" if self.is_success() else "x"
+        string = f"[{success}] {self.task.name}\n"
+        for test in self.successes:
+            string += f"        {str(test)}\n"
+        for test in self.failures:
+            string += f"    (x) {str(test)}\n"
+        return string
+
+    def is_success(self) -> bool:
+        return len(self.failures) == 0
+
+
+class RunResults:
+    def __init__(self, site: TestConfig, results: List[SingleRunResult]):
+        self.site = site
+        self.results = results
+
+    def __str__(self) -> str:
+        return "\n".join(str(r) for r in self.results)
+
+    def is_success(self) -> bool:
+        return all([r.is_success() for r in self.results])
+
+
+class RunnerResult:
+    def __init__(self, results: List[RunResults]):
+        self.results = results
+
+    def __str__(self) -> str:
+        successes = 0
+        failures = 0
+        for r in self.results:
+            for sr in r.results:
+                successes += len(sr.successes)
+                failures += len(sr.failures)
+
+        total = successes + failures
+        if total == 0:
+            return "No tests run"
+        summary = f"Result: {round(100 * successes / total)} % ({successes} / {total})"
+        return "\n".join(str(r) for r in self.results) + "\n" + summary
+
+    def is_success(self) -> bool:
+        return all([r.is_success() for r in self.results])
 
 
 class TestRunner:
-    def __init__(self, sites: List[TestConfig]):
+    def __init__(self, sites: List[TestConfig], headless=True):
         self.sites = sites
+        self.headless = headless
 
-    def run(self):
+    def run(self) -> RunnerResult:
+        results: List[RunResults] = []
         for site in self.sites:
             try:
                 site.setup.start()
-                self._run_tasks(site.tasks)
+                task_results = self._run_tasks(site.tasks)
+                results.append(RunResults(site, task_results))
             finally:
                 site.setup.stop()
 
+        return RunnerResult(results)
+
     def _run_tasks(self, tasks: List[Task]):
+        results: List[SingleRunResult] = []
         for task in tasks:
             try:
-                self._run_single_task(task)
+                r = self._run_single_task(task)
+                results.append(r)
             except Exception as e:
                 print(e)
 
-    def _run_single_task(self, task: Task):
-        driver = SeleniumDriver(headless=False)
+        return results
+
+    def _run_single_task(self, task: Task) -> SingleRunResult:
+        driver = SeleniumDriver(headless=self.headless)
         action_engine = ActionEngine(driver=driver)
         world_model = WorldModel()
-        agent = WebAgent(world_model, action_engine)
+        agent = WebAgent(world_model, action_engine, n_steps=task.max_steps)
         agent.get(task.url)
-        agent.run(task.prompt)
+        agent.run(task.prompt, disable_animation=True)
+        dataframe = agent.logger.return_pandas()
         context = self._get_context(agent)
+        driver.destroy()
 
+        result = SingleRunResult(task, dataframe)
         for test in task.tests:
-            test.is_passing(context)
+            error = test.get_error(context)
+            if error is None:
+                result.successes.append(test)
+            else:
+                result.failures.append(TestFailure(test, error))
+
+        return result
 
     def _get_context(self, agent: WebAgent) -> Dict[str, str]:
         return {
             "URL": agent.driver.get_url(),
             "Status": "success" if agent.result.success else "failure",
             "Output": agent.result.output,
+            "Steps": agent.logger.current_step,
+            "HTML": agent.driver.get_html(),
         }
 
     def __str__(self) -> str:

--- a/lavague-tests/lavague/tests/runner.py
+++ b/lavague-tests/lavague/tests/runner.py
@@ -1,0 +1,52 @@
+from typing import List, Dict
+from lavague.core.agents import WebAgent
+from lavague.core.world_model import WorldModel
+from lavague.core.action_engine import ActionEngine
+from lavague.drivers.selenium.base import SeleniumDriver
+from .config import Task, TestConfig
+
+
+class RunResult:
+    success: int
+
+
+class TestRunner:
+    def __init__(self, sites: List[TestConfig]):
+        self.sites = sites
+
+    def run(self):
+        for site in self.sites:
+            try:
+                site.setup.start()
+                self._run_tasks(site.tasks)
+            finally:
+                site.setup.stop()
+
+    def _run_tasks(self, tasks: List[Task]):
+        for task in tasks:
+            try:
+                self._run_single_task(task)
+            except Exception as e:
+                print(e)
+
+    def _run_single_task(self, task: Task):
+        driver = SeleniumDriver(headless=False)
+        action_engine = ActionEngine(driver=driver)
+        world_model = WorldModel()
+        agent = WebAgent(world_model, action_engine)
+        agent.get(task.url)
+        agent.run(task.prompt)
+        context = self._get_context(agent)
+
+        for test in task.tests:
+            test.is_passing(context)
+
+    def _get_context(self, agent: WebAgent) -> Dict[str, str]:
+        return {
+            "URL": agent.driver.get_url(),
+            "Status": "success" if agent.result.success else "failure",
+            "Output": agent.result.output,
+        }
+
+    def __str__(self) -> str:
+        return "\n".join([str(s) for s in self.sites])

--- a/lavague-tests/lavague/tests/runner.py
+++ b/lavague-tests/lavague/tests/runner.py
@@ -103,11 +103,11 @@ class TestRunner:
 
     def _run_single_task(self, task: Task) -> SingleRunResult:
         driver = SeleniumDriver(headless=self.headless)
-        action_engine = ActionEngine(driver=driver)
+        action_engine = ActionEngine(driver=driver, n_attempts=task.n_attempts)
         world_model = WorldModel()
         agent = WebAgent(world_model, action_engine, n_steps=task.max_steps)
         agent.get(task.url)
-        agent.run(task.prompt, disable_animation=True)
+        agent.run(task.prompt, user_data=task.user_data)
         dataframe = agent.logger.return_pandas()
         context = self._get_context(agent)
         driver.destroy()

--- a/lavague-tests/lavague/tests/setup.py
+++ b/lavague-tests/lavague/tests/setup.py
@@ -16,7 +16,7 @@ class Setup:
 
     @staticmethod
     def parse(directory: str, args: Dict) -> "Setup":
-        if "type" not in args:
+        if args.get("type", "web") == "web":
             return Setup()
 
         if args["type"] == "static":

--- a/lavague-tests/lavague/tests/setup.py
+++ b/lavague-tests/lavague/tests/setup.py
@@ -1,0 +1,38 @@
+from typing import Dict
+import http.server
+import socketserver
+
+
+class Setup:
+    default_url: str = None
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    @staticmethod
+    def parse(args: Dict) -> "Setup":
+        if "type" not in args:
+            return Setup()
+
+        if args["type"] == "static":
+            return StaticServer(args.get("directory", "www", args.get("port", "8000")))
+
+
+class StaticServer(Setup):
+    default_url = "http://localhost:8000"
+
+    def __init__(self, directory: str, port: str):
+        self.directory = directory
+        self.port = port
+
+    def start(self):
+        with socketserver.TCPServer(
+            ("", self.port),
+            lambda r, c: http.server.SimpleHTTPRequestHandler(
+                r, c, directory=self.directory
+            ),
+        ) as httpd:
+            httpd.serve_forever()

--- a/lavague-tests/lavague/tests/test.py
+++ b/lavague-tests/lavague/tests/test.py
@@ -1,16 +1,17 @@
 from abc import ABC, abstractmethod
 import re
 from typing import Callable, Dict, Any, Union, Optional
+from operator import eq, ne, contains, lt, gt
 
 OperatorFunction = Callable[[Any, Any], bool]
 
 operators: Dict[str, OperatorFunction] = {
-    "is": lambda a, b: a == b,
-    "is not": lambda a, b: a != b,
-    "is lower than": lambda a, b: a < b,
-    "is greater than": lambda a, b: a > b,
-    "contains": lambda a, b: b in a,
-    "does not contain": lambda a, b: b not in a,
+    "is": eq,
+    "is not": ne,
+    "is lower than": lt,
+    "is greater than": gt,
+    "contains": contains,
+    "does not contain": lambda a, b: not contains(a, b),
 }
 
 
@@ -39,7 +40,10 @@ class ExpectTest(TaskTest):
             self.op = operators[match.group(2)]
             self.value = match.group(3)
         else:
-            raise ValueError(f"Invalid expect string '{expect}'")
+            available = ", ".join(operators.keys())
+            raise ValueError(
+                f"Invalid expect string '{expect}', available operators are {available}"
+            )
 
     def get_error(self, context: Any) -> Optional[str]:
         prop_value = context.get(self.prop, "")

--- a/lavague-tests/lavague/tests/test.py
+++ b/lavague-tests/lavague/tests/test.py
@@ -1,0 +1,52 @@
+from abc import ABC, abstractmethod
+import re
+from typing import Callable, Dict, Any, Union
+
+OperatorFunction = Callable[[Any, Any], bool]
+
+operators: Dict[str, OperatorFunction] = {
+    "is": lambda a, b: a == b,
+    "is not": lambda a, b: a != b,
+    "is lower than": lambda a, b: a < b,
+    "is greater than": lambda a, b: a > b,
+    "contains": lambda a, b: b in a,
+    "does not contain": lambda a, b: b not in a,
+}
+
+
+def add_operator(name: str, fn: OperatorFunction):
+    operators[name] = fn
+
+
+class TaskTest(ABC):
+    @abstractmethod
+    def is_passing(self, context: Any) -> bool:
+        pass
+
+
+class ExpectTest(TaskTest):
+    prop: str
+    op: OperatorFunction
+    value: str
+
+    def __init__(self, expect: str):
+        operator_pattern = "|".join(re.escape(op) for op in operators)
+        pattern = rf"([\s\w]+)\s*({operator_pattern})\s*(.+)"
+        match = re.match(pattern, expect)
+        if match:
+            self.prop = match.group(1).strip()
+            self.op = operators[match.group(2)]
+            self.value = match.group(3)
+        else:
+            raise ValueError(f"Invalid expect string '{expect}'")
+
+    def is_passing(self, context: Any) -> bool:
+        prop_value = context.get(self.prop, "")
+        op_fn = operators[self.op]
+        return op_fn(prop_value, self.value)
+
+    @classmethod
+    def parse(cls, tests: Union[str, list[str]]) -> list[TaskTest]:
+        if isinstance(tests, str):
+            tests = [tests]
+        return [cls(test) for test in tests]

--- a/lavague-tests/pyproject.toml
+++ b/lavague-tests/pyproject.toml
@@ -1,0 +1,33 @@
+[tool.poetry]
+name = "lavague-tests"
+version = "0.0.1"
+description = "Test runner for Lavague"
+authors = ["lavague-ai"]
+readme = "README.md"
+license = "Apache-2.0"
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Software Development :: Libraries :: Application Frameworks",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "License :: OSI Approved :: Apache Software License",
+]
+keywords = ["LAM", "action", "automation", "LLM", "NLP", "RAG", "selenium", "selenium"]
+homepage = "https://lavague.ai"
+repository = "https://github.com/lavague-ai/LaVague/"
+documentation = "https://docs.lavague.ai/en/latest/"
+packages = [{include = "lavague/"}]
+
+[tool.poetry.dependencies]
+python = "^3.10.0"
+lavague-core = "^0.2.0"
+click = "^8.1.7"
+lavague-drivers-selenium = "^0.2.6"
+
+[tool.poetry.scripts]
+lavague-test = "lavague.tests.cli:cli"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"

--- a/lavague-tests/sites/examples/config.yml
+++ b/lavague-tests/sites/examples/config.yml
@@ -1,0 +1,12 @@
+type: static
+port: 8000
+directory: www
+tasks:
+
+  - name: Navigate using link
+    url: http://localhost:8000
+    prompt: Go to the menu
+    expect:
+      - URL is http://localhost:8000/menu.html
+      - Status is success
+      - HTML contains <h1>Menu</h1>

--- a/lavague-tests/sites/examples/www/index.html
+++ b/lavague-tests/sites/examples/www/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Navigation Example</title>
+</head>
+
+<body>
+  <h1>Welcome to the Main Page</h1>
+  <p>
+    Click the link below to navigate to the menu.
+  </p>
+  <a href="./menu.html">See the menu</a>
+</body>
+
+</html>

--- a/lavague-tests/sites/examples/www/menu.html
+++ b/lavague-tests/sites/examples/www/menu.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Menu</title>
+</head>
+
+<body>
+  <h1>Menu</h1>
+  <p>Welcome to the menu!</p>
+</body>
+
+</html>

--- a/lavague-tests/sites/google.com/config.yml
+++ b/lavague-tests/sites/google.com/config.yml
@@ -1,0 +1,6 @@
+tasks:
+  - url: https://google.com
+    prompt: "Go to LaVague.ai"
+    expect:
+      - URL is https://lavague.ai
+      - Status is success

--- a/lavague-tests/sites/huggingface.co/config.yml
+++ b/lavague-tests/sites/huggingface.co/config.yml
@@ -1,0 +1,16 @@
+tasks:
+
+  - name: HuggingFace navigation
+    url: https://huggingface.co/docs
+    prompt: Go on the quicktour of PEFT
+    expect:
+      - URL is https://huggingface.co/docs/peft/quicktour
+      - Status is success
+      - HTML contains PEFT offers parameter-efficient methods for finetuning large pretrained models
+
+  - name: HuggingFace search
+    url: https://huggingface.co
+    prompt: Find the-wave-250 dataset
+    expect:
+      - URL is https://huggingface.co/datasets/BigAction/the-wave-250
+      - Status is success


### PR DESCRIPTION
Provide a CLI tool `lavague-test`
Given configuration files:
```yaml
tasks:
  - name: HuggingFace search
    url: https://huggingface.co
    prompt: Find the-wave-250 dataset
    expect:
      - URL is https://huggingface.co/datasets/BigAction/the-wave-250
      - Status is success
```
```yaml
type: static
port: 8000
directory: www
tasks:
  - name: Navigate using link
    url: http://localhost:8000
    prompt: Go to the menu
    expect:
      - URL is http://localhost:8000/menu.html
      - Status is success
      - HTML contains <h1>Menu</h1>

```
it generates a run report:
```
[o] HuggingFace search
        URL is https://huggingface.co/datasets/BigAction/the-wave-250
        Status is success

[x] Go to LaVague.ai from https://google.com
    (x) URL is https://lavague.ai - was: https://www.google.com/search?sca_esv=15a9157023f07e80&q=LaV
    (x) Status is success - was: failure

[o] Navigate using link
        URL is http://localhost:8000/menu.html
        Status is success
        HTML contains <h1>Menu</h1>

Result: 71 % (5 / 7)
```