### PR TITLE
bugfix: cost eval logic

### DIFF
--- a/lavague-core/lavague/core/agents.py
+++ b/lavague-core/lavague/core/agents.py
@@ -410,7 +410,7 @@ class WebAgent:
             "input_tokens"
         )
         mm_llm_token_cost_output = (
-            self.mm_llm_token_counter.total_llm_token_count / 1000000
+            self.mm_llm_token_counter.completion_llm_token_count / 1000000
         ) * self.pricing_data.get("gpt-4o", {"gpt-4o": {"output_tokens": 0}}).get(
             "output_tokens"
         )
@@ -424,7 +424,7 @@ class WebAgent:
         cost_dict = {
             "embedding_tokens_cost": embedding_token_cost,
             "llm_prompt_tokens_cost": mm_llm_token_cost_input,
-            "llm_completion_tokens": mm_llm_token_cost_output,
+            "llm_completion_tokens_cost": mm_llm_token_cost_output,
             "total_cost_per_step": total_cost_per_step,
         }
         self.logger.add_log(cost_dict)


### PR DESCRIPTION
- cost output should be the cost of the completion tokens and not of the total tokens
- value should be saved as `llm_completion_tokens_cost` as to not overwrite `llm_completions_token`

embedding tokens are still broken but this should at least partially fix the cost eval logic