### PR TITLE
fix: don't remove xpathed elements while expanding to parent node

### DIFF
--- a/lavague-core/lavague/core/retrievers.py
+++ b/lavague-core/lavague/core/retrievers.py
@@ -439,16 +439,10 @@ class FromXPathNodesExpansionRetriever(BaseHtmlRetriever):
                     element = element.parent
                     chunk = str(element)
                     parent_xpaths = set(self.get_included_xpaths(element))
+                    processed_xpaths.update(parent_xpaths)
 
                     # Remove previous chunks that are now included in the parent
-                    r_get_xpath = r' xpath=["\'](.*?)["\']'
-                    chunks = [
-                        c
-                        for c in chunks
-                        if parent_xpaths.isdisjoint(
-                            [x for x in re.findall(r_get_xpath, c)]
-                        )
-                    ]
+                    chunks = [c for c in chunks if c not in chunk]
 
             if chunk.strip():
                 chunks.append(chunk)


### PR DESCRIPTION
When an expanding chunk is colliding with already processed one, it doesn't necessarily means that it is fully included. We should remove it only if the new node fully include the previously processed node.