### PR TITLE
Fix/yaml check to handle incorrect handling of numeric values in action YAML

### DIFF
--- a/lavague-core/lavague/core/utilities/format_utils.py
+++ b/lavague-core/lavague/core/utilities/format_utils.py
@@ -24,6 +24,31 @@ class VariableVisitor(ast.NodeVisitor):
             if isinstance(target, ast.Name):  # Ensure it's a variable assignment
                 self.output.append(target.id)
 
+def quote_numeric_yaml_values(yaml_string):
+    """Wrap numeric values in quotes in a YAML string.
+    
+    This is helpful when the YAML might contain numeric values that are not wrapped in quotes which can cause issues when parsing the YAML.
+    In Navigation Engine, we expect values to be always strings, so this avoids issues when the YAML does not wrap numeric values in quotes, such as outputting "value: 01" instead of "value: '01'".
+    
+    """
+    def replace_value(match):
+        full_match, value = match.groups()
+        try:
+            # Try to convert to float to catch both integers and decimal numbers
+            float(value)
+            # If successful, it's a number, so wrap it in quotes
+            return f'value: "{value}"'
+        except ValueError:
+            # If it's not a number, return the original match
+            return full_match
+
+    # Regex to match 'value:' followed by a space and then any non-space characters
+    pattern = r'(value: (\S+))'
+    
+    # Replace values that are numeric
+    modified_yaml = re.sub(pattern, replace_value, yaml_string)
+    
+    return modified_yaml
 
 def return_assigned_variables(code_snippet):
     """Returns the variables assigned in a code snippet."""

--- a/lavague-core/lavague/core/utilities/format_utils.py
+++ b/lavague-core/lavague/core/utilities/format_utils.py
@@ -24,13 +24,15 @@ class VariableVisitor(ast.NodeVisitor):
             if isinstance(target, ast.Name):  # Ensure it's a variable assignment
                 self.output.append(target.id)
 
+
 def quote_numeric_yaml_values(yaml_string):
     """Wrap numeric values in quotes in a YAML string.
-    
+
     This is helpful when the YAML might contain numeric values that are not wrapped in quotes which can cause issues when parsing the YAML.
     In Navigation Engine, we expect values to be always strings, so this avoids issues when the YAML does not wrap numeric values in quotes, such as outputting "value: 01" instead of "value: '01'".
-    
+
     """
+
     def replace_value(match):
         full_match, value = match.groups()
         try:
@@ -42,13 +44,14 @@ def quote_numeric_yaml_values(yaml_string):
             # If it's not a number, return the original match
             return full_match
 
-    # Regex to match 'value:' followed by a space and then any non-space characters
-    pattern = r'(value: (\S+))'
-    
+    # Regex to match 'value:' followed by a space and then any numeric
+    pattern = r"(value: ([\d.]+))"
+
     # Replace values that are numeric
     modified_yaml = re.sub(pattern, replace_value, yaml_string)
-    
+
     return modified_yaml
+
 
 def return_assigned_variables(code_snippet):
     """Returns the variables assigned in a code snippet."""

--- a/lavague-integrations/drivers/lavague-drivers-selenium/lavague/drivers/selenium/base.py
+++ b/lavague-integrations/drivers/lavague-drivers-selenium/lavague/drivers/selenium/base.py
@@ -21,7 +21,10 @@ from lavague.core.base_driver import (
 from PIL import Image
 from io import BytesIO
 from selenium.webdriver.chrome.options import Options
-from lavague.core.utilities.format_utils import extract_code_from_funct, quote_numeric_yaml_values
+from lavague.core.utilities.format_utils import (
+    extract_code_from_funct,
+    quote_numeric_yaml_values,
+)
 from selenium.webdriver.common.action_chains import ActionChains
 import yaml
 
@@ -175,7 +178,7 @@ driver.set_window_size({width}, {height} + height_difference)
 
         # Ensures that numeric values are quoted
         generated_code = quote_numeric_yaml_values(generated_code)
-        
+
         data = yaml.safe_load(generated_code)
         if not isinstance(data, List):
             data = [data]
@@ -256,7 +259,7 @@ driver.set_window_size({width}, {height} + height_difference)
     ):
         # Ensures that numeric values are quoted to avoid issues with YAML parsing
         code = quote_numeric_yaml_values(code)
-        
+
         data = yaml.safe_load(code)
         if not isinstance(data, List):
             data = [data]

--- a/lavague-integrations/drivers/lavague-drivers-selenium/lavague/drivers/selenium/base.py
+++ b/lavague-integrations/drivers/lavague-drivers-selenium/lavague/drivers/selenium/base.py
@@ -21,7 +21,7 @@ from lavague.core.base_driver import (
 from PIL import Image
 from io import BytesIO
 from selenium.webdriver.chrome.options import Options
-from lavague.core.utilities.format_utils import extract_code_from_funct
+from lavague.core.utilities.format_utils import extract_code_from_funct, quote_numeric_yaml_values
 from selenium.webdriver.common.action_chains import ActionChains
 import yaml
 
@@ -173,6 +173,9 @@ driver.set_window_size({width}, {height} + height_difference)
     def get_highlighted_element(self, generated_code: str):
         elements = []
 
+        # Ensures that numeric values are quoted
+        generated_code = quote_numeric_yaml_values(generated_code)
+        
         data = yaml.safe_load(generated_code)
         if not isinstance(data, List):
             data = [data]
@@ -251,6 +254,9 @@ driver.set_window_size({width}, {height} + height_difference)
         globals: dict[str, Any] = None,
         locals: Mapping[str, object] = None,
     ):
+        # Ensures that numeric values are quoted to avoid issues with YAML parsing
+        code = quote_numeric_yaml_values(code)
+        
         data = yaml.safe_load(code)
         if not isinstance(data, List):
             data = [data]
@@ -267,6 +273,8 @@ driver.set_window_size({width}, {height} + height_difference)
                     self.set_value(args["xpath"], args["value"], True)
                 elif action_name == "dropdownSelect":
                     self.dropdown_select(args["xpath"], args["value"])
+                elif action_name == "fail":
+                    raise Exception("Action generation failed. Reason: ", args["value"])
                 else:
                     raise ValueError(f"Unknown action: {action_name}")
 
@@ -484,7 +492,8 @@ Arguments:
 Name: fail
 Description: Indicate that you are unable to complete the task and explain why.
 Arguments:
-  - value (string)
+  - xpath (string): Always set to an empty string
+  - value (string): Detailled explanation of why the task cannot be completed
 
 Here are examples of previous answers:
 HTML:


### PR DESCRIPTION
@adeprez can you check this PR? 

It's just some util and extra check to make sure the YAML generated is interpreted as strings and not automatically convert to numbers which makes things crash