### PR TITLE
Updated Selenium control for typing keys

### DIFF
--- a/lavague-integrations/drivers/lavague-drivers-selenium/lavague/drivers/selenium/base.py
+++ b/lavague-integrations/drivers/lavague-drivers-selenium/lavague/drivers/selenium/base.py
@@ -335,10 +335,16 @@ driver.set_window_size({width}, {height} + height_difference)
             # might not be a clearable element, but global click + send keys can still success
             pass
         self.click(xpath)
-        
-        (ActionChains(self.driver).key_down(Keys.CONTROL).send_keys('a').key_up(Keys.CONTROL)
-         .send_keys(Keys.DELETE) # clear the input field
-         .send_keys(value).perform())
+
+        (
+            ActionChains(self.driver)
+            .key_down(Keys.CONTROL)
+            .send_keys("a")
+            .key_up(Keys.CONTROL)
+            .send_keys(Keys.DELETE)  # clear the input field
+            .send_keys(value)
+            .perform()
+        )
         if enter:
             ActionChains(self.driver).send_keys(Keys.ENTER).perform()
         self.driver.switch_to.default_content()

--- a/lavague-integrations/drivers/lavague-drivers-selenium/lavague/drivers/selenium/base.py
+++ b/lavague-integrations/drivers/lavague-drivers-selenium/lavague/drivers/selenium/base.py
@@ -335,7 +335,10 @@ driver.set_window_size({width}, {height} + height_difference)
             # might not be a clearable element, but global click + send keys can still success
             pass
         self.click(xpath)
-        ActionChains(self.driver).send_keys(value).perform()
+        
+        (ActionChains(self.driver).key_down(Keys.CONTROL).send_keys('a').key_up(Keys.CONTROL)
+         .send_keys(Keys.DELETE) # clear the input field
+         .send_keys(value).perform())
         if enter:
             ActionChains(self.driver).send_keys(Keys.ENTER).perform()
         self.driver.switch_to.default_content()


### PR DESCRIPTION
We don't clear the previous input, and if the Navigation Engine tries several times it will accumulate mistakes like this if the first step works but not the others: 

![image](https://github.com/user-attachments/assets/8fdc8a4d-ed9a-4f5a-9b19-78e380407c6d)
