### PR TITLE
Add `origin` to telemetry

### DIFF
--- a/lavague-core/lavague/core/agents.py
+++ b/lavague-core/lavague/core/agents.py
@@ -258,7 +258,7 @@ class WebAgent:
                 history,
                 output,
             )
-        send_telemetry(logger.return_pandas())
+        send_telemetry(logger.return_pandas(), origin="gradio")
         url_input = self.action_engine.driver.get_url()
         if output is not None:
             if len(output) > 0 and output.strip() != "[NONE]":
@@ -374,7 +374,8 @@ class WebAgent:
             self.interrupted = True
             raise e
         finally:
-            send_telemetry(self.logger.return_pandas())
+            origin = self.origin if hasattr(self, "origin") else "lavague"
+            send_telemetry(self.logger.return_pandas(), origin=origin)
             if log_to_db:
                 local_db_logger = LocalDBLogger()
                 local_db_logger.insert_logs(self)
@@ -448,3 +449,6 @@ class WebAgent:
             print(
                 f"No previous nodes available. Please run the agent atleast once to view previous steps"
             )
+            
+    def set_origin(self, origin: str):
+        self.origin = origin

--- a/lavague-core/lavague/core/utilities/telemetry.py
+++ b/lavague-core/lavague/core/utilities/telemetry.py
@@ -26,7 +26,7 @@ logging_print.addHandler(ch)
 logging_print.propagate = False
 
 
-def send_telemetry(logger_telemetry: DataFrame, test: bool = False):
+def send_telemetry(logger_telemetry: DataFrame, origin: str, test: bool = False):
     try:
         if TELEMETRY_VAR is None:
             logger_telemetry = logger_telemetry.drop(
@@ -37,6 +37,8 @@ def send_telemetry(logger_telemetry: DataFrame, test: bool = False):
             )
             logger_telemetry = logger_telemetry.drop("html", axis=1, errors="ignore")
             logger_telemetry = logger_telemetry.replace({np.nan: None})
+            
+            logger_telemetry["origin"] = origin
 
             for index, row in logger_telemetry.iterrows():
                 logger_telemetry.at[index, "unique_user_id"] = UNIQUE_ID

--- a/lavague-qa/lavague/qa/generator.py
+++ b/lavague-qa/lavague/qa/generator.py
@@ -134,7 +134,7 @@ class TestGenerator:
         )
         world_model = WorldModel.from_context(context=self.context)
         agent = WebAgent(world_model, action_engine, token_counter=self.token_counter)
-
+        agent.set_origin("lavague-qa")
         agent.get(self.url)
         time.sleep(1)
 


### PR DESCRIPTION
- add `origin` field to `send_telemetry`
- add `set_origin(origin)` to WebAgent
- use `set_origin` in `lavague-qa`

Add default telemetry to be: 
- default agent.run: `lavague`
- from gradio: `gradio`
- from LaVague QA: `lavague-qa`

Usage: 
```py
agent = WebAgent(world_model, action_engine)
agent.set_origin("lavague-qa")
```