### PR TITLE
Correct model name in OpenAI integration docs

### DIFF
--- a/docs/docs/integrations/openai.md
+++ b/docs/docs/integrations/openai.md
@@ -27,7 +27,7 @@ You can find a list of OpenAI models currently available and their names [here](
 from lavague.contexts.openai import OpenaiContext
 
 # Initialize Context
-context = OpenaiContext(llm="GPT-4o mini", mm_llm="GPT-4o mini")
+context = OpenaiContext(llm="gpt-4o-mini", mm_llm="gpt-4o-mini")
 ```
 Once we have defined our OpenaiContext, we can use it by passing it to our ActionEngine and WorldModel when initializing them with the `from_context()` method.
 


### PR DESCRIPTION
This is a small correction of the code sample to set a custom OpenAI context. The identifier `GPT-4o mini` causes an error message (`Invalid model`).

### Testing
Ran `mkdocs serve` and verified changes.