### PR TITLE
Resolve issue with network idle timeout

### DIFF
--- a/lavague-integrations/drivers/lavague-drivers-playwright/lavague/drivers/playwright/base.py
+++ b/lavague-integrations/drivers/lavague-drivers-playwright/lavague/drivers/playwright/base.py
@@ -4,7 +4,7 @@ import os
 from PIL import Image
 from typing import Callable, Optional, Any, Mapping, Dict, List
 from lavague.core.utilities.format_utils import extract_code_from_funct
-from playwright.sync_api import Page, Locator
+from playwright.sync_api import Page, Locator, TimeoutError
 from lavague.core.base_driver import (
     BaseDriver,
     JS_GET_INTERACTIVES,
@@ -286,8 +286,7 @@ class PlaywrightDriver(BaseDriver):
             self.page.wait_for_load_state(
                 "networkidle", timeout=self.waiting_completion_timeout * 1000
             )
-        except:
-            # timeout occurred
+        except TimeoutError:
             pass
         elapsed = time.time() - t
         self.wait_for_dom_stable(self.waiting_completion_timeout - elapsed)

--- a/lavague-integrations/drivers/lavague-drivers-playwright/lavague/drivers/playwright/base.py
+++ b/lavague-integrations/drivers/lavague-drivers-playwright/lavague/drivers/playwright/base.py
@@ -30,8 +30,8 @@ class PlaywrightDriver(BaseDriver):
         width: int = 1080,
         height: int = 1080,
         user_data_dir: Optional[str] = None,
-        log_waiting_time=False,
-        waiting_completion_timeout=10,
+        log_waiting_time: bool = False,
+        waiting_completion_timeout: int = 10,  # seconds
     ):
         os.environ["PW_TEST_SCREENSHOT_NO_FONTS_READY"] = (
             "1"  # Allow playwright to take a screenshots even if the fonts won't load in head mode.
@@ -284,7 +284,7 @@ class PlaywrightDriver(BaseDriver):
         t = time.time()
         try:
             self.page.wait_for_load_state(
-                "networkidle", timeout=self.waiting_completion_timeout
+                "networkidle", timeout=self.waiting_completion_timeout * 1000
             )
         except:
             # timeout occurred
@@ -380,7 +380,7 @@ HTML:
 <tab class="devsite-active" xpath="/html/body/section/devsite-header/div/div[1]/div/div/div[2]/div[1]/devsite-tabs/nav/tab[1]">
 <a aria-label="Gemini API, selected" class="devsite-tabs-content gc-analytics-event" data-category="Site-Wide Custom Events" data-label="Tab: Gemini API" href="https://ai.google.dev/gemini-api" track-metadata-eventdetail="https://ai.google.dev/gemini-api" track-metadata-module="primary nav" track-metadata-position="nav - gemini api" track-name="gemini api" track-type="nav" xpath="/html/body/section/devsite-header/div/div[1]/div/div/div[2]/div[1]/devsite-tabs/nav/tab[1]/a">
     Gemini API
-  
+
     </a>
 </tab>
 <tab class="devsite-overflow-tab" xpath="/html/body/section/devsite-header/div/div[1]/div/div/div[2]/div[1]/devsite-tabs/nav/tab[2]"><!-- -->
@@ -389,12 +389,12 @@ HTML:
 <tab xpath="/html/body/section/devsite-header/div/div[1]/div/div/div[2]/div[1]/devsite-tabs/nav/tab[2]/div/tab[1]">
 <a class="devsite-tabs-content gc-analytics-event" data-category="Site-Wide Custom Events" data-label="Tab: Gemma" href="https://ai.google.dev/gemma" track-metadata-eventdetail="https://ai.google.dev/gemma" track-metadata-module="primary nav" track-metadata-position="nav - gemma" track-name="gemma" track-type="nav" xpath="/html/body/section/devsite-header/div/div[1]/div/div/div[2]/div[1]/devsite-tabs/nav/tab[2]/div/tab[1]/a">
     Gemma
-  
+
     </a>
 </tab><tab xpath="/html/body/section/devsite-header/div/div[1]/div/div/div[2]/div[1]/devsite-tabs/nav/tab[2]/div/tab[2]">
 <a class="devsite-tabs-content gc-analytics-event" data-category="Site-Wide Custom Events" data-label="Tab: Google AI Edge" href="https://ai.google.dev/edge" track-metadata-eventdetail="https://ai.google.dev/edge" track-metadata-module="primary nav" track-metadata-position="nav - google ai edge" track-name="google ai edge" track-type="nav" xpath="/html/body/section/devsite-header/div/div[1]/div/div/div[2]/div[1]/devsite-tabs/nav/tab[2]/div/tab[2]/a">
     Google AI Edge
-  
+
 
 Query: Click on "Gemma" under the "More" dropdown menu.
 Completion:


### PR DESCRIPTION
I think you don't use the Playwright anymore. BTW, I believe, the timeout for `"networkidle"` is 10 secs, not 10 ms as the `page.wait_for_load_state()` method's `timeout` param gets milliseconds.

PS: I was using this code part of the LaVague (`wait_for_idle()` method in playwright) which had a problem, and this PR will resolve the issue.